### PR TITLE
Final Test Reliability Fixes

### DIFF
--- a/packages/critters/package.json
+++ b/packages/critters/package.json
@@ -62,7 +62,7 @@
     "build:watch": "tsup --watch",
     "dev": "tsup --watch",
     "clean": "rm -rf dist",
-    "test": "vitest run",
+    "test": "vitest run --passWithNoTests",
     "test:watch": "vitest",
     "test:coverage": "vitest run --coverage",
     "lint": "eslint src test",

--- a/packages/next-circuit-breaker/package.json
+++ b/packages/next-circuit-breaker/package.json
@@ -41,7 +41,7 @@
     "dev": "tsup --watch",
     "lint": "eslint src/",
     "typecheck": "tsc --noEmit",
-    "test": "vitest run",
+    "test": "vitest run --passWithNoTests",
     "test:watch": "vitest",
     "test:coverage": "vitest run --coverage",
     "clean": "rm -rf dist coverage node_modules"

--- a/packages/next-connect/package.json
+++ b/packages/next-connect/package.json
@@ -40,7 +40,7 @@
     "dev": "tsup --watch",
     "lint": "eslint src --ext ts --ignore-path .gitignore",
     "typecheck": "tsc --noEmit",
-    "test": "vitest run",
+    "test": "vitest run --passWithNoTests",
     "test:watch": "vitest",
     "test:coverage": "vitest run --coverage"
   },

--- a/packages/next-cookies/package.json
+++ b/packages/next-cookies/package.json
@@ -42,7 +42,7 @@
     "dev": "tsup --watch",
     "lint": "eslint src/",
     "typecheck": "tsc --noEmit",
-    "test": "vitest run",
+    "test": "vitest run --passWithNoTests",
     "test:watch": "vitest",
     "test:coverage": "vitest run --coverage",
     "clean": "rm -rf dist coverage node_modules"

--- a/packages/next-csrf/package.json
+++ b/packages/next-csrf/package.json
@@ -44,7 +44,7 @@
     "dev": "tsup --watch",
     "lint": "eslint src/",
     "typecheck": "tsc --noEmit",
-    "test": "vitest run",
+    "test": "vitest run --passWithNoTests",
     "test:watch": "vitest",
     "test:coverage": "vitest run --coverage",
     "clean": "rm -rf dist coverage node_modules"

--- a/packages/next-images/package.json
+++ b/packages/next-images/package.json
@@ -60,7 +60,7 @@
     "dev": "tsup --watch",
     "lint": "eslint src/",
     "typecheck": "tsc --noEmit",
-    "test": "vitest run",
+    "test": "vitest run --passWithNoTests",
     "test:watch": "vitest",
     "test:coverage": "vitest run --coverage",
     "clean": "rm -rf dist coverage node_modules"

--- a/packages/next-json-ld/package.json
+++ b/packages/next-json-ld/package.json
@@ -48,7 +48,7 @@
     "dev": "tsup --watch",
     "lint": "eslint src/",
     "typecheck": "tsc --noEmit",
-    "test": "vitest run",
+    "test": "vitest run --passWithNoTests",
     "test:watch": "vitest",
     "test:coverage": "vitest run --coverage",
     "clean": "rm -rf dist coverage node_modules"

--- a/packages/next-pwa/package.json
+++ b/packages/next-pwa/package.json
@@ -47,7 +47,7 @@
     "lint": "eslint .",
     "lint:fix": "eslint . --fix",
     "typecheck": "tsc --noEmit",
-    "test": "vitest run",
+    "test": "vitest run --passWithNoTests",
     "test:watch": "vitest",
     "test:coverage": "vitest run --coverage",
     "clean": "rm -rf dist coverage"

--- a/packages/next-session/package.json
+++ b/packages/next-session/package.json
@@ -30,7 +30,7 @@
     "dev": "tsup --watch",
     "lint": "eslint src --ext ts --ignore-path .gitignore",
     "typecheck": "tsc --noEmit",
-    "test": "vitest run",
+    "test": "vitest run --passWithNoTests",
     "test:watch": "vitest",
     "test:coverage": "vitest run --coverage"
   },

--- a/packages/react-a11y-utils/package.json
+++ b/packages/react-a11y-utils/package.json
@@ -48,7 +48,7 @@
     "dev": "tsup --watch",
     "lint": "eslint src/",
     "typecheck": "tsc --noEmit",
-    "test": "vitest run",
+    "test": "vitest run --passWithNoTests",
     "test:watch": "vitest",
     "test:coverage": "vitest run --coverage",
     "clean": "rm -rf dist coverage node_modules"

--- a/packages/react-virtualized/package.json
+++ b/packages/react-virtualized/package.json
@@ -12,7 +12,7 @@
   "scripts": {
     "build:types": "flow-copy-source --ignore \"**/*.{jest,e2e,ssr,example}.js\" source/WindowScroller dist/es/WindowScroller && flow-copy-source --ignore \"**/*.{jest,e2e,ssr,example}.js\" source/AutoSizer dist/es/AutoSizer",
     "build": "tsup",
-    "test": "vitest run",
+    "test": "vitest run --passWithNoTests",
     "test:watch": "vitest",
     "test:coverage": "vitest run --coverage",
     "lint": "eslint 'source/**/*.js'",

--- a/packages/seeded-rng/package.json
+++ b/packages/seeded-rng/package.json
@@ -48,7 +48,7 @@
     "dev": "tsup --watch",
     "lint": "eslint src/",
     "typecheck": "tsc --noEmit",
-    "test": "vitest run",
+    "test": "vitest run --passWithNoTests",
     "test:watch": "vitest",
     "test:coverage": "vitest run --coverage",
     "clean": "rm -rf dist coverage node_modules"


### PR DESCRIPTION
Adds --passWithNoTests to all packages to prevent Turbo from failing when a package has no unit tests (like next-pwa which only has playwright integration tests).