### PR TITLE
fix: critters Windows path

### DIFF
--- a/packages/critters/test/critters.test.js
+++ b/packages/critters/test/critters.test.js
@@ -15,7 +15,7 @@
  */
 
 import { describe, it, expect, vi } from 'vitest';
-import Critters from '../src/index.js';
+import Critters from '../src/runtime.js';
 import fs from 'fs';
 import path from 'path';
 import { fileURLToPath } from 'url';

--- a/packages/critters/test/security.test.js
+++ b/packages/critters/test/security.test.js
@@ -15,7 +15,7 @@
  */
 
 import { describe, it, expect } from 'vitest';
-import Critters from '../src/index.js';
+import Critters from '../src/runtime.js';
 
 /**
  * Check if HTML contains a script tag with specific content


### PR DESCRIPTION
Fixes critters test importing renamed index.js on Windows runners