### PR TITLE
fix(ci): use pnpm/action-setup@v3 in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,7 +21,7 @@ jobs:
           node-version: 20
 
       - name: Install pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@v3
         with:
           version: 9
 


### PR DESCRIPTION
The release workflow was using  which reads  from  () and conflicts with the explicit  parameter. Switching to  (same as CI) fixes the version mismatch.