### PR TITLE
fix(monorepo): fix CJS interop for default exports

### DIFF
--- a/packages/next-compose-plugins/src/index.js
+++ b/packages/next-compose-plugins/src/index.js
@@ -34,5 +34,8 @@ const extend = baseConfig => ({
   },
 });
 
+withPlugins.optional = markOptional;
+withPlugins.extend = extend;
+
 export { withPlugins, extend, markOptional as optional };
 export default withPlugins;

--- a/packages/next-compose-plugins/tsup.config.ts
+++ b/packages/next-compose-plugins/tsup.config.ts
@@ -6,4 +6,11 @@ export default defineConfig({
   dts: true,
   clean: true,
   external: ['next'],
+  splitting: false,
+  footer(ctx) {
+    if (ctx.format === 'cjs') {
+      return { js: 'if (module.exports.default) module.exports = module.exports.default;' }
+    }
+    return {}
+  },
 })

--- a/packages/next-images/tsup.config.ts
+++ b/packages/next-images/tsup.config.ts
@@ -10,4 +10,10 @@ export default defineConfig({
   minify: false,
   treeshake: true,
   external: [],
+  footer(ctx) {
+    if (ctx.format === 'cjs') {
+      return { js: 'if (module.exports.default) module.exports = module.exports.default;' }
+    }
+    return {}
+  },
 });


### PR DESCRIPTION
This PR fixes a  error in the compatibility tests. 

The issue was that  was wrapping the default export in  for CJS builds when named exports were also present. Added a  to  to unwrap the default export and manually attached named exports as properties to ensure compatibility with both CJS  and ESM .