### PR TITLE
fix(next-optimized-images): include lib/ in package files

### DIFF
--- a/packages/next-optimized-images/package.json
+++ b/packages/next-optimized-images/package.json
@@ -7,6 +7,7 @@
   "types": "dist/index.d.ts",
   "files": [
     "dist",
+    "lib",
     "llms.txt"
   ],
   "scripts": {


### PR DESCRIPTION
The dist/index.js references ./loaders/... which resolves relative to dist/, but loader files are in lib/. Adding lib/ to files array fixes npm pack.