### PR TITLE
ci(release): skip browser downloads to fix timeout

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,6 +10,8 @@ concurrency: ${{ github.workflow }}-${{ github.ref }}
 
 env:
   HUSKY: 0
+  PUPPETEER_SKIP_DOWNLOAD: 1
+  PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD: 1
 
 jobs:
   build-and-pack:


### PR DESCRIPTION
pnpm install hung on puppeteer postinstall. Adding skip env vars.