### PR TITLE
fix(next-optimized-images): copy loaders into dist/

### DIFF
--- a/packages/next-optimized-images/package.json
+++ b/packages/next-optimized-images/package.json
@@ -11,7 +11,7 @@
     "llms.txt"
   ],
   "scripts": {
-    "build": "tsup",
+    "build": "tsup && mkdir -p dist/loaders && cp -rv lib/loaders/* dist/loaders/",
     "watch": "tsup --watch",
     "lint": "eslint . --ignore-pattern examples",
     "lint:fix": "eslint . --ignore-pattern examples --fix",


### PR DESCRIPTION
dist/index.js resolves ./loaders/ relative to itself, but loaders were only in lib/. Build now copies them into dist/.