### PR TITLE
fix(next-optimized-images): copy all loader deps to dist/

### DIFF
--- a/packages/next-optimized-images/package.json
+++ b/packages/next-optimized-images/package.json
@@ -11,7 +11,7 @@
     "llms.txt"
   ],
   "scripts": {
-    "build": "tsup && mkdir -p dist/loaders && cp -rv lib/loaders/* dist/loaders/",
+    "build": "tsup && mkdir -p dist/loaders && cp -rv lib/loaders/* dist/loaders/ && cp lib/loaders/optimized-buffer-loader.js lib/loaders/svg-sprite-loader/svg-runtime-generator.js dist/",
     "watch": "tsup --watch",
     "lint": "eslint . --ignore-pattern examples",
     "lint:fix": "eslint . --ignore-pattern examples --fix",


### PR DESCRIPTION
dist/index.js also references optimized-buffer-loader.js and svg-runtime-generator.js via __dirname paths.