### PR TITLE
ci(release): add write permissions for changeset release PR

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,6 +8,10 @@ on:
 
 concurrency: ${{ github.workflow }}-${{ github.ref }}
 
+permissions:
+  contents: write
+  pull-requests: write
+
 env:
   HUSKY: 0
   PUPPETEER_SKIP_DOWNLOAD: 1


### PR DESCRIPTION
The release workflow failed with a 403 when trying to create the changeset release branch/PR. Adding explicit write permissions for contents and pull-requests.