### PR TITLE
fix(ci): exclude showcase on Node 18 and fix Windows build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -157,21 +157,33 @@ jobs:
 
       - name: Test
         run: |
+          TURBO_FILTER="${{ needs.detect-affected.outputs.turbo_filter }}"
           if [ "${{ needs.detect-affected.outputs.has_targets }}" = "true" ]; then
-            pnpm turbo run test:coverage --cache-dir="$TURBO_CACHE_DIR" --filter="...${{ needs.detect-affected.outputs.turbo_filter }}..."
+            pnpm turbo run test:coverage --cache-dir="$TURBO_CACHE_DIR" --filter="...${TURBO_FILTER}..."
           else
             pnpm turbo run test:coverage --cache-dir="$TURBO_CACHE_DIR"
           fi
         if: matrix.os == 'ubuntu-latest' && matrix.node == 20
 
+      - name: Test (Node 18, exclude showcase)
+        run: |
+          TURBO_FILTER="${{ needs.detect-affected.outputs.turbo_filter }}"
+          if [ "${{ needs.detect-affected.outputs.has_targets }}" = "true" ]; then
+            pnpm turbo run test --cache-dir="$TURBO_CACHE_DIR" --filter="...${TURBO_FILTER}..." --filter="!showcase"
+          else
+            pnpm turbo run test --cache-dir="$TURBO_CACHE_DIR" --filter="!showcase"
+          fi
+        if: matrix.node == 18
+
       - name: Test (no coverage)
         run: |
+          TURBO_FILTER="${{ needs.detect-affected.outputs.turbo_filter }}"
           if [ "${{ needs.detect-affected.outputs.has_targets }}" = "true" ]; then
-            pnpm turbo run test --cache-dir="$TURBO_CACHE_DIR" --filter="...${{ needs.detect-affected.outputs.turbo_filter }}..."
+            pnpm turbo run test --cache-dir="$TURBO_CACHE_DIR" --filter="...${TURBO_FILTER}..."
           else
             pnpm turbo run test --cache-dir="$TURBO_CACHE_DIR"
           fi
-        if: matrix.os != 'ubuntu-latest' || matrix.node != 20
+        if: matrix.os != 'ubuntu-latest' || (matrix.node != 20 && matrix.node != 18)
 
       - name: Upload Coverage
         if: matrix.os == 'ubuntu-latest' && matrix.node == 20

--- a/packages/next-optimized-images/package.json
+++ b/packages/next-optimized-images/package.json
@@ -11,7 +11,7 @@
     "llms.txt"
   ],
   "scripts": {
-    "build": "tsup && mkdir -p dist/loaders && cp -rv lib/loaders/* dist/loaders/ && cp lib/loaders/optimized-buffer-loader.js lib/loaders/svg-sprite-loader/svg-runtime-generator.js dist/",
+    "build": "tsup && shx mkdir -p dist/loaders && shx cp -rv lib/loaders/* dist/loaders/ && shx cp lib/loaders/optimized-buffer-loader.js lib/loaders/svg-sprite-loader/svg-runtime-generator.js dist/",
     "watch": "tsup --watch",
     "lint": "eslint . --ignore-pattern examples",
     "lint:fix": "eslint . --ignore-pattern examples --fix",
@@ -50,6 +50,7 @@
   "devDependencies": {
     "@vitest/coverage-v8": "^2.1.9",
     "next": "^16.0.0",
+    "shx": "^0.4.0",
     "tsup": "^8.5.1",
     "typescript": "^5.9.3",
     "vitest": "^2.1.9",

--- a/packages/next-optimized-images/package.json
+++ b/packages/next-optimized-images/package.json
@@ -11,7 +11,7 @@
     "llms.txt"
   ],
   "scripts": {
-    "build": "tsup && shx mkdir -p dist/loaders && shx cp -rv lib/loaders/* dist/loaders/ && shx cp lib/loaders/optimized-buffer-loader.js lib/loaders/svg-sprite-loader/svg-runtime-generator.js dist/",
+    "build": "tsup && shx mkdir -p dist/loaders && shx cp -r lib/loaders/* dist/loaders/ && shx cp lib/loaders/optimized-buffer-loader.js lib/loaders/svg-sprite-loader/svg-runtime-generator.js dist/",
     "watch": "tsup --watch",
     "lint": "eslint . --ignore-pattern examples",
     "lint:fix": "eslint . --ignore-pattern examples --fix",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -793,6 +793,9 @@ importers:
       next:
         specifier: '>=16.1.7'
         version: 16.2.0(@babel/core@7.29.0)(@playwright/test@1.58.2)(babel-plugin-macros@3.1.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      shx:
+        specifier: ^0.4.0
+        version: 0.4.0
       tsup:
         specifier: ^8.5.1
         version: 8.5.1(@swc/core@1.15.13)(jiti@2.6.1)(postcss@8.5.8)(tsx@4.19.3)(typescript@5.9.3)(yaml@2.8.2)
@@ -6262,6 +6265,10 @@ packages:
     resolution: {integrity: sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==}
     engines: {node: '>=0.8.x'}
 
+  execa@1.0.0:
+    resolution: {integrity: sha512-adbxcyWV46qiHyvSp50TKt05tB4tK3HcmF7/nxfAdhnox83seTDbwnaqKO4sXRy7roHAIFqJP/Rw/AuEbX61LA==}
+    engines: {node: '>=6'}
+
   execa@4.1.0:
     resolution: {integrity: sha512-j5W0//W7f8UxAn8hXVnwG8tLwdiUy4FJLcSupCg6maBYZDpyBvTApK7KyuI4bKj8KOh1r2YH+6ucuYtJv1bTZA==}
     engines: {node: '>=10'}
@@ -6594,6 +6601,10 @@ packages:
   get-stdin@9.0.0:
     resolution: {integrity: sha512-dVKBjfWisLAicarI2Sf+JuBE/DghV4UzNAVe9yhEJuzeREd3JhOTE9cUaJTeSa77fsbQUK3pcOpJfM59+VKZaA==}
     engines: {node: '>=12'}
+
+  get-stream@4.1.0:
+    resolution: {integrity: sha512-GMat4EJ5161kIy2HevLlr4luNjBgvmj413KaQA7jt4V8B4RDsfpHk7WQ9GVqfYyyx8OS/L66Kox+rJRNklLK7w==}
+    engines: {node: '>=6'}
 
   get-stream@5.2.0:
     resolution: {integrity: sha512-nBF+F1rAZVCu/p7rjzgA+Yb4lfYXrpl7a6VmJrU8wF9I1CKvP/QwPNZHnOlwbTkY6dvtFIzFMSyQXbLoTQPRpA==}
@@ -6970,6 +6981,10 @@ packages:
     resolution: {integrity: sha512-5Hh7Y1wQbvY5ooGgPbDaL5iYLAPzMTUrjMulskHLH6wnv/A+1q5rgEaiuqEjB+oxGXIVZs1FF+R/KPN3ZSQYYg==}
     engines: {node: '>=12'}
 
+  interpret@1.4.0:
+    resolution: {integrity: sha512-agE4QfB2Lkp9uICn7BAqoscw4SZP9kTE2hxiFI3jBPmXJfdqiahTbUuKGsMoN2GtqL9AxhYioAcVvgsb1HvRbA==}
+    engines: {node: '>= 0.10'}
+
   ip-address@10.1.0:
     resolution: {integrity: sha512-XXADHxXmvT9+CRxhXg56LJovE+bmWnEWB78LB83VZTprKTmaC5QfruXocxzTZ2Kl0DNwKuBdlIhjL8LeY8Sf8Q==}
     engines: {node: '>= 12'}
@@ -7157,6 +7172,10 @@ packages:
   is-shared-array-buffer@1.0.4:
     resolution: {integrity: sha512-ISWac8drv4ZGfwKl5slpHG9OwPNty4jOWPRIhBpxOoD+hqITiwuipOQ2bNthAzwA3B4fIjO4Nln74N0S9byq8A==}
     engines: {node: '>= 0.4'}
+
+  is-stream@1.1.0:
+    resolution: {integrity: sha512-uQPm8kcs47jx38atAcWTVxyltQYoPT68y9aWYdV6yWXSyW8mzSat0TL6CiWdZeCdF3KrAvpVtnHbTv4RN+rqdQ==}
+    engines: {node: '>=0.10.0'}
 
   is-stream@2.0.1:
     resolution: {integrity: sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==}
@@ -8463,6 +8482,10 @@ packages:
     engines: {node: '>= 4'}
     hasBin: true
 
+  npm-run-path@2.0.2:
+    resolution: {integrity: sha512-lJxZYlT4DW/bRUtFh1MQIWqmLwQfAxnqWG4HhEdjMlkrJYnJn0Jrr2u3mgxqaWsdiBc76TYkTG/mhrnYTuzfHw==}
+    engines: {node: '>=4'}
+
   npm-run-path@4.0.1:
     resolution: {integrity: sha512-S48WzZW777zhNIrn7gxOlISNAqi9ZC/uQFnRdbeIHhZhCA6UqpkOT8T1G7BvfdgP4Er8gF4sUbaS0i7QvIfCWw==}
     engines: {node: '>=8'}
@@ -9583,6 +9606,10 @@ packages:
     resolution: {integrity: sha512-YTUo+Flmw4ZXiWfQKGcwwc11KnoRAYgzAE2E7mXKCjSviTKShtxBsN6YUUBB2gtaBzKzeKunxhUwNHQuRryhWA==}
     engines: {node: '>= 4'}
 
+  rechoir@0.6.2:
+    resolution: {integrity: sha512-HFM8rkZ+i3zrV+4LQjwQ0W+ez98pApMGM3HUrN04j3CqzPOzl9nmP15Y8YXNm8QHGv/eacOVEjqhmWpkRV0NAw==}
+    engines: {node: '>= 0.10'}
+
   recma-build-jsx@1.0.0:
     resolution: {integrity: sha512-8GtdyqaBcDfva+GUKDr3nev3VpKAhup1+RvkMvUxURHpW7QyIvk9F5wz7Vzo06CEMSilw6uArgRqhpiUcWp8ew==}
 
@@ -10013,11 +10040,21 @@ packages:
     resolution: {integrity: sha512-ObmnIF4hXNg1BqhnHmgbDETF8dLPCggZWBjkQfhZpbszZnYur5DUljTcCHii5LC3J5E0yeO/1LIMyH+UvHQgyw==}
     engines: {node: '>= 0.4'}
 
+  shelljs@0.9.2:
+    resolution: {integrity: sha512-S3I64fEiKgTZzKCC46zT/Ib9meqofLrQVbpSswtjFfAVDW+AZ54WTnAM/3/yENoxz/V1Cy6u3kiiEbQ4DNphvw==}
+    engines: {node: '>=18'}
+    hasBin: true
+
   shellwords@0.1.1:
     resolution: {integrity: sha512-vFwSUfQvqybiICwZY5+DAWIPLKsWO31Q91JSKl3UYv+K5c2QRPzn0qzec6QPu1Qc9eHYItiP3NdJqNVqetYAww==}
 
   shiki@3.23.0:
     resolution: {integrity: sha512-55Dj73uq9ZXL5zyeRPzHQsK7Nbyt6Y10k5s7OjuFZGMhpp4r/rsLBH0o/0fstIzX1Lep9VxefWljK/SKCzygIA==}
+
+  shx@0.4.0:
+    resolution: {integrity: sha512-Z0KixSIlGPpijKgcH6oCMCbltPImvaKy0sGH8AkLRXw1KyzpKtaCTizP2xen+hNDqVF4xxgvA0KXSb9o4Q6hnA==}
+    engines: {node: '>=18'}
+    hasBin: true
 
   side-channel-list@1.0.0:
     resolution: {integrity: sha512-FCLHtRD/gnpCiCHEiJLOwdmFP+wzCmDEkc9y7NsYxeF4u7Btsn1ZuwgwJGxImImHicJArLP4R0yX4c2KCrMrTA==}
@@ -10292,6 +10329,10 @@ packages:
   strip-comments@2.0.1:
     resolution: {integrity: sha512-ZprKx+bBLXv067WTCALv8SSz5l2+XhpYCsVtSqlMnkAXMWDq+/ekVbl1ghqP9rUHTzv6sm/DwCOiYutU/yp1fw==}
     engines: {node: '>=10'}
+
+  strip-eof@1.0.0:
+    resolution: {integrity: sha512-7FCwGGmx8mD5xQd3RPUvnSpUXHM3BWuzjtpD4TXsfcZ9EL4azvVVUscFYwD9nx8Kh+uCBC00XBtAykoMHwTh8Q==}
+    engines: {node: '>=0.10.0'}
 
   strip-final-newline@2.0.0:
     resolution: {integrity: sha512-BrpvfNAE3dcvq7ll3xVumzjKjZQ5tI1sEUIKr3Uoks0XUl45St3FlatVqef9prk4jRDzhW6WZg+3bk93y6pLjA==}
@@ -17782,6 +17823,16 @@ snapshots:
 
   events@3.3.0: {}
 
+  execa@1.0.0:
+    dependencies:
+      cross-spawn: 6.0.6
+      get-stream: 4.1.0
+      is-stream: 1.1.0
+      npm-run-path: 2.0.2
+      p-finally: 1.0.0
+      signal-exit: 3.0.7
+      strip-eof: 1.0.0
+
   execa@4.1.0:
     dependencies:
       cross-spawn: 7.0.6
@@ -18153,6 +18204,10 @@ snapshots:
       es-object-atoms: 1.1.1
 
   get-stdin@9.0.0: {}
+
+  get-stream@4.1.0:
+    dependencies:
+      pump: 3.0.3
 
   get-stream@5.2.0:
     dependencies:
@@ -18615,6 +18670,8 @@ snapshots:
 
   internmap@2.0.3: {}
 
+  interpret@1.4.0: {}
+
   ip-address@10.1.0: {}
 
   iron-webcrypto@1.2.1: {}
@@ -18774,6 +18831,8 @@ snapshots:
   is-shared-array-buffer@1.0.4:
     dependencies:
       call-bound: 1.0.4
+
+  is-stream@1.1.0: {}
 
   is-stream@2.0.1: {}
 
@@ -21256,6 +21315,10 @@ snapshots:
       shell-quote: 1.8.3
       string.prototype.padend: 3.1.6
 
+  npm-run-path@2.0.2:
+    dependencies:
+      path-key: 2.0.1
+
   npm-run-path@4.0.1:
     dependencies:
       path-key: 3.1.1
@@ -22416,6 +22479,10 @@ snapshots:
       tiny-invariant: 1.3.3
       tslib: 2.8.1
 
+  rechoir@0.6.2:
+    dependencies:
+      resolve: 1.22.11
+
   recma-build-jsx@1.0.0:
     dependencies:
       '@types/estree': 1.0.8
@@ -23028,6 +23095,13 @@ snapshots:
 
   shell-quote@1.8.3: {}
 
+  shelljs@0.9.2:
+    dependencies:
+      execa: 1.0.0
+      fast-glob: 3.3.3
+      interpret: 1.4.0
+      rechoir: 0.6.2
+
   shellwords@0.1.1:
     optional: true
 
@@ -23041,6 +23115,11 @@ snapshots:
       '@shikijs/types': 3.23.0
       '@shikijs/vscode-textmate': 10.0.2
       '@types/hast': 3.0.4
+
+  shx@0.4.0:
+    dependencies:
+      minimist: 1.2.8
+      shelljs: 0.9.2
 
   side-channel-list@1.0.0:
     dependencies:
@@ -23355,6 +23434,8 @@ snapshots:
   strip-bom@4.0.0: {}
 
   strip-comments@2.0.1: {}
+
+  strip-eof@1.0.0: {}
 
   strip-final-newline@2.0.0: {}
 


### PR DESCRIPTION
## Summary

Two CI fixes:

1. **Exclude showcase from Node 18 test runs** — Commit 85e586651 made turbo test tasks depend on their own build (`dependsOn: ["^build", "build"]`). This causes turbo to build ALL packages including `showcase` before testing. But `showcase` uses Next.js 16 which requires Node 20+. This broke the Node 18 test job. Fixed by adding a dedicated Node 18 test step that excludes `showcase` via `--filter=!showcase`.

2. **Fix Windows build for next-optimized-images** — The build script used Unix `cp` and `mkdir` commands which fail on Windows CMD. Replaced with cross-platform `shx` commands.

## Testing

- Build: `pnpm build` passes locally
- All existing tests continue to pass
