### PR TITLE
test(next-optimized-images): isolate loader detection fixture

### DIFF
--- a/packages/next-optimized-images/__tests__/loaders/index.test.js
+++ b/packages/next-optimized-images/__tests__/loaders/index.test.js
@@ -6,10 +6,11 @@ const {
   appendLoaders,
 } = require('../../lib/loaders');
 const { getConfig } = require('../../lib/config');
+const fs = require('fs');
+const os = require('os');
 const path = require('path');
 
 const imageminPluginPath = path.join(__dirname, '../fixtures/imagemin-plugin.js');
-const testFixturesPath = path.join(__dirname, '../fixtures');
 
 describe('next-optimized-images/loaders', () => {
   it('detects if a module is installed', () => {
@@ -20,17 +21,23 @@ describe('next-optimized-images/loaders', () => {
   });
 
   it('detects installed loaders', () => {
-    expect(detectLoaders(testFixturesPath)).toEqual({
-      jpeg: false,
-      gif: false,
-      svg: false,
-      svgSprite: false,
-      webp: false,
-      png: false,
-      lqip: false,
-      responsive: false,
-      responsiveAdapter: false,
-    });
+    const emptyResolvePath = fs.mkdtempSync(path.join(os.tmpdir(), 'next-optimized-images-'));
+
+    try {
+      expect(detectLoaders(emptyResolvePath)).toEqual({
+        jpeg: false,
+        gif: false,
+        svg: false,
+        svgSprite: false,
+        webp: false,
+        png: false,
+        lqip: false,
+        responsive: false,
+        responsiveAdapter: false,
+      });
+    } finally {
+      fs.rmSync(emptyResolvePath, { recursive: true, force: true });
+    }
   });
 
   it('returns the handled image types', () => {


### PR DESCRIPTION
## Summary
- Makes the next-optimized-images loader detection test use a temporary empty resolution root instead of the shared fixtures directory.
- Prevents ignored/local fixture node_modules content from changing the expected optional-loader detection result.

## Root cause
The failing assertion expected every optional optimization loader to be absent while resolving from `__tests__/fixtures`. That directory can contain ignored local `node_modules` test fixtures, so `require.resolve()` correctly found optional loaders such as `svg-sprite-loader` and made the test environment-dependent.

## Review
- Security: test-only change; no secrets or external input paths committed.
- Quality: minimal fixture isolation; temporary directory is cleaned in `finally`.
- Regression coverage: the existing loader detection test now asserts the no-loader case from a guaranteed empty resolution root.

## Tests
- `git diff --check main...HEAD`
- diff/secret review of `main...HEAD`
- `corepack pnpm@9.6.0 --filter @opensourceframework/next-optimized-images test`
- `corepack pnpm@9.6.0 test`
- `corepack pnpm@9.6.0 lint`
- GitHub PR checks: all passing