### PR TITLE
chore: align root pnpm version

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "node": ">=18",
     "pnpm": ">=9"
   },
-  "packageManager": "pnpm@9.0.0",
+  "packageManager": "pnpm@9.6.0",
   "pnpm": {
     "overrides": {
       "@types/react": "^19.0.0",


### PR DESCRIPTION
## Summary
- Updates the root packageManager field from pnpm 9.0.0 to pnpm 9.6.0.
- Aligns Corepack's default workspace pnpm with the next-iron-session package, whose package-local metadata already requires pnpm 9.6.0.
- Prevents root-level maintenance commands from defaulting to the older pnpm 9.0.0 toolchain.

## Tests
- corepack pnpm@9.6.0 install --frozen-lockfile
- corepack pnpm@9.6.0 --version
- corepack pnpm --version
- corepack pnpm --filter @opensourceframework/next-iron-session exec node -e "console.log(process.env.npm_config_user_agent)"
- corepack pnpm@9.6.0 --filter @opensourceframework/next-iron-session test
- git diff --check
- staged secret scan