### PR TITLE
fix(showcase): use eslint for lint script

### DIFF
--- a/showcase/package.json
+++ b/showcase/package.json
@@ -6,7 +6,7 @@
     "dev": "next dev",
     "build": "next build --webpack",
     "start": "next start",
-    "lint": "next lint || true"
+    "lint": "eslint ."
   },
   "dependencies": {
     "@opensourceframework/critters": "workspace:*",


### PR DESCRIPTION
## Summary
- Replace the removed/unsupported `next lint || true` showcase lint script with `eslint .`.
- Stops the showcase lint task from masking the Next 16 `next lint` failure as a successful lint run.

## Root Cause
Next.js 16 no longer provides the old `next lint` workflow used by the showcase script; the trailing `|| true` hid the failure, so Turbo reported lint success even though no real showcase linting happened.

## Tests
- `corepack pnpm@9.6.0 --filter showcase lint`
- `corepack pnpm@9.6.0 lint`
- `git diff --check`

## Notes
Existing pre-user working tree changes were left untouched: root package files, docs/plans, and modal_qwen scripts.