### PR TITLE
fix(bcryptjs): update bcrypt dev dependency

### DIFF
--- a/packages/bcryptjs/package.json
+++ b/packages/bcryptjs/package.json
@@ -67,7 +67,7 @@
     "crypto": false
   },
   "devDependencies": {
-    "bcrypt": "^5.1.1",
+    "bcrypt": "^6.0.0",
     "esm2umd": "^0.3.1",
     "prettier": "^3.5.0",
     "typescript": "^5.7.3"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -122,8 +122,8 @@ importers:
   packages/bcryptjs:
     devDependencies:
       bcrypt:
-        specifier: ^5.1.1
-        version: 5.1.1(encoding@0.1.13)
+        specifier: ^6.0.0
+        version: 6.0.0
       esm2umd:
         specifier: ^0.3.1
         version: 0.3.1
@@ -4913,6 +4913,16 @@ packages:
   bcrypt@5.1.1:
     resolution: {integrity: sha512-AGBHOG5hPYZ5Xl9KXzU5iKq9516yEmvCKDg3ecP5kX2aB6UqTeXZxk2ELnDgDm6BQSMlLt9rDB4LoSMx0rYwww==}
     engines: {node: '>= 10.0.0'}
+
+  bcrypt@6.0.0:
+    resolution: {integrity: sha512-cU8v/EGSrnH+HnxV2z0J7/blxH8gq7Xh2JFT6Aroax7UohdmiJJlxApMxtKfuI7z68NvvVcmR78k2LbT6efhRg==}
+    engines: {node: '>= 18'}
+  node-addon-api@8.7.0:
+    resolution: {integrity: sha512-9MdFxmkKaOYVTV+XVRG8ArDwwQ77XIgIPyKASB1k3JPq3M8fGQQQE3YpMOrKm6g//Ktx8ivZr8xo1Qmtqub+GA==}
+    engines: {node: ^18 || ^20 || >= 21}
+  node-gyp-build@4.8.4:
+    resolution: {integrity: sha512-LA4ZjwlnUblHVgq0oBF3Jl/6h/Nvs5fzBLwdEF4nuxnFdsfajde4WfxtJr3CaiH+F6ewcIB/q4jQ4UzPyid+CQ==}
+    hasBin: true
 
   better-path-resolve@1.0.0:
     resolution: {integrity: sha512-pbnl5XzGBdrFU/wT4jqmJVPn2B6UHPBOhzMQkY/SPUPB6QtUXtmBHBIwCbXJol93mOpGMnQyP/+BB19q04xj7g==}
@@ -16110,6 +16120,15 @@ snapshots:
     transitivePeerDependencies:
       - encoding
       - supports-color
+
+  bcrypt@6.0.0:
+    dependencies:
+      node-addon-api: 8.7.0
+      node-gyp-build: 4.8.4
+
+  node-addon-api@8.7.0: {}
+
+  node-gyp-build@4.8.4: {}
 
   better-path-resolve@1.0.0:
     dependencies:


### PR DESCRIPTION
## Summary
- Updates the bcryptjs package's bcrypt dev dependency from 5.1.1 to 6.0.0.
- Removes the active audit path through @mapbox/node-pre-gyp -> tar 6.2.1; high audit count drops from 60 to 54 and tar advisories disappear.

## Tests
- corepack pnpm@9.6.0 install --frozen-lockfile --offline
- corepack pnpm@9.6.0 --filter @opensourceframework/bcryptjs test
- corepack pnpm@9.6.0 --filter @opensourceframework/bcryptjs lint
- corepack pnpm@9.6.0 audit --audit-level high --json (remaining known backlog: 54 high, 59 moderate, 10 low; no tar advisories)
- git diff --check

## Review
- Checked staged diff and ran changed-line secret scan before commit.