### PR TITLE
fix(showcase): run eslint directly

### DIFF
--- a/showcase/package.json
+++ b/showcase/package.json
@@ -6,7 +6,7 @@
     "dev": "next dev",
     "build": "next build --webpack",
     "start": "next start",
-    "lint": "next lint || true"
+    "lint": "eslint ."
   },
   "dependencies": {
     "@opensourceframework/critters": "workspace:*",


### PR DESCRIPTION
## Summary
- Replace the removed/misparsed `next lint || true` showcase script with a direct `eslint .` invocation.
- Stops the showcase lint task from printing `Invalid project directory .../showcase/lint` and masking failures under Next 16.

## Tests
- `corepack pnpm@9.6.0 --filter showcase lint`
- `corepack pnpm@9.6.0 lint`
- `git diff --check`
- staged secret scan