### PR TITLE
fix(showcase): run eslint directly

### DIFF
--- a/showcase/package.json
+++ b/showcase/package.json
@@ -6,7 +6,7 @@
     "dev": "next dev",
     "build": "next build --webpack",
     "start": "next start",
-    "lint": "next lint || true"
+    "lint": "eslint ."
   },
   "dependencies": {
     "@opensourceframework/critters": "workspace:*",


### PR DESCRIPTION
## Summary
- Replace the deprecated/removed `next lint || true` showcase script with `eslint .`.
- Restores real lint execution under Next 16 instead of masking the invalid `next lint` command.

## Root cause
Next 16 no longer provides `next lint`; the old script interpreted `lint` as a project directory and then swallowed the failure with `|| true`.

## Tests
- `corepack pnpm@9.6.0 --filter showcase lint`
- `corepack pnpm@9.6.0 lint`