### PR TITLE
fix(next-auth): silence OAuth placeholder lint warnings

### DIFF
--- a/packages/next-auth/src/server/lib/oauth/client.js
+++ b/packages/next-auth/src/server/lib/oauth/client.js
@@ -237,15 +237,17 @@ class OAuth1Client {
     this.provider = provider
   }
 
-  async getOAuthRequestToken(params = {}) {
-    throw new Error("OAuth 1.0a is not yet fully implemented in the native client. Please use OAuth 2.0 or contact maintainers.")
+  async getOAuthRequestToken(_params = {}) {
+    throw new Error(
+      "OAuth 1.0a is not yet fully implemented in the native client. Please use OAuth 2.0 or contact maintainers."
+    )
   }
 
-  async getOAuthAccessToken(oauth_token, oauth_token_secret, oauth_verifier) {
+  async getOAuthAccessToken(_oauth_token, _oauth_token_secret, _oauth_verifier) {
     throw new Error("OAuth 1.0a is not yet fully implemented in the native client.")
   }
 
-  async get(url, oauth_token, oauth_token_secret) {
+  async get(_url, _oauth_token, _oauth_token_secret) {
     throw new Error("OAuth 1.0a is not yet fully implemented in the native client.")
   }
 }


### PR DESCRIPTION
## Summary
- Prefix unused OAuth 1.0a placeholder arguments with underscores so the package lint rule recognizes them as intentionally unused.
- Keeps the current not-implemented behavior unchanged.

## Tests
- corepack pnpm@9.6.0 --filter @opensourceframework/next-auth lint
- corepack pnpm@9.6.0 --filter @opensourceframework/next-auth test
- git diff --check
- staged changed-line secret scan

## Review
- Security: no user input, auth flow, secrets, or external call behavior changed.
- Error handling: existing explicit not-implemented errors preserved.
- Quality: removes lint noise without changing public API or runtime semantics.