### PR TITLE
fix(showcase): use eslint for lint script

### DIFF
--- a/showcase/package.json
+++ b/showcase/package.json
@@ -6,7 +6,7 @@
     "dev": "next dev",
     "build": "next build --webpack",
     "start": "next start",
-    "lint": "next lint || true"
+    "lint": "eslint ."
   },
   "dependencies": {
     "@opensourceframework/critters": "workspace:*",


### PR DESCRIPTION
## Summary
- replaces the removed Next.js `next lint` command in the showcase app with direct `eslint .`
- removes the `|| true` masking so showcase lint failures fail the workspace lint task

## Tests
- `corepack pnpm@9.6.0 --filter showcase lint`
- `corepack pnpm@9.6.0 lint`
- `corepack pnpm@9.6.0 test`