### PR TITLE
fix(next-mdx-toc): preserve inline heading text

### DIFF
--- a/.changeset/fix-next-mdx-toc-inline-headings.md
+++ b/.changeset/fix-next-mdx-toc-inline-headings.md
@@ -1,0 +1,5 @@
+---
+'@opensourceframework/next-mdx-toc': patch
+---
+
+Preserve inline code and formatted text when generating table-of-contents titles from MDX headings.

--- a/packages/next-mdx-toc/src/index.ts
+++ b/packages/next-mdx-toc/src/index.ts
@@ -17,20 +17,21 @@ interface Items {
 type TocNode = List | ListItem | Paragraph | null | undefined;
 
 function getTextContent(children: PhrasingContent[]): string | undefined {
-  for (const child of children) {
-    if (child.type === 'text') {
-      return child.value;
-    }
-
-    if ('children' in child) {
-      const nestedText = getTextContent(child.children as PhrasingContent[]);
-      if (nestedText) {
-        return nestedText;
+  const text = children
+    .map((child) => {
+      if ('value' in child && typeof child.value === 'string') {
+        return child.value;
       }
-    }
-  }
 
-  return undefined;
+      if ('children' in child) {
+        return getTextContent(child.children as PhrasingContent[]) ?? '';
+      }
+
+      return '';
+    })
+    .join('');
+
+  return text || undefined;
 }
 
 function isItem(value: Partial<Item> | Items): value is Item {

--- a/packages/next-mdx-toc/test/index.test.js
+++ b/packages/next-mdx-toc/test/index.test.js
@@ -1,16 +1,28 @@
-import fs from "fs"
-import path from "path"
-import { getTableOfContents } from "../src"
+import fs from 'fs';
+import path from 'path';
+import { getTableOfContents } from '../src';
 
-const doc = fs.readFileSync(
-  path.join(__dirname, "./__fixtures__/example.mdx"),
-  "utf8"
-)
+const doc = fs.readFileSync(path.join(__dirname, './__fixtures__/example.mdx'), 'utf8');
 
 const node = {
   content: doc,
-}
+};
 
-test("returns toc tree from node", async () => {
-  expect(await getTableOfContents(node)).toMatchSnapshot()
-})
+test('returns toc tree from node', async () => {
+  expect(await getTableOfContents(node)).toMatchSnapshot();
+});
+
+test('preserves inline heading text in toc titles', async () => {
+  expect(
+    await getTableOfContents({
+      content: '# Configure `next.config.js` for **images**',
+    })
+  ).toEqual({
+    items: [
+      {
+        title: 'Configure next.config.js for images',
+        url: '#configure-nextconfigjs-for-images',
+      },
+    ],
+  });
+});


### PR DESCRIPTION
## Summary
- Fixes TOC title extraction so headings with inline code/bold/emphasis keep all visible text instead of only the first text node.
- Adds a regression test for a formatted MDX heading.
- Adds a patch changeset for @opensourceframework/next-mdx-toc.

## Tests
- corepack pnpm@9.6.0 --filter @opensourceframework/next-mdx-toc test
- corepack pnpm@9.6.0 --filter @opensourceframework/next-mdx-toc build
- corepack pnpm@9.6.0 lint
- corepack pnpm@9.6.0 exec prettier --check packages/next-mdx-toc/src/index.ts packages/next-mdx-toc/test/index.test.js .changeset/fix-next-mdx-toc-inline-headings.md
- git diff --check
- staged changed-line secret scan