### PR TITLE
fix(bcryptjs): remove unused native bcrypt dev dependency

### DIFF
--- a/.changeset/remove-bcryptjs-native-devdep.md
+++ b/.changeset/remove-bcryptjs-native-devdep.md
@@ -1,0 +1,5 @@
+---
+'@opensourceframework/bcryptjs': patch
+---
+
+Remove the unused native `bcrypt` development dependency to eliminate vulnerable install-time transitive packages from the workspace audit surface.

--- a/packages/bcryptjs/package.json
+++ b/packages/bcryptjs/package.json
@@ -67,7 +67,6 @@
     "crypto": false
   },
   "devDependencies": {
-    "bcrypt": "^5.1.1",
     "esm2umd": "^0.3.1",
     "prettier": "^3.5.0",
     "typescript": "^5.7.3"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -121,9 +121,6 @@ importers:
 
   packages/bcryptjs:
     devDependencies:
-      bcrypt:
-        specifier: ^5.1.1
-        version: 5.1.1(encoding@0.1.13)
       esm2umd:
         specifier: ^0.3.1
         version: 0.3.1
@@ -4909,10 +4906,6 @@ packages:
     resolution: {integrity: sha512-VoMINM2rqJwJgfdHq6RiUudKt2BV+FY5ZFezP/ypmwayk68+NzzAQy4XXLlqsGD4MCzq3DrmNFD/uUmBJuGoXw==}
     engines: {node: '>=10.0.0'}
     deprecated: Security vulnerability fixed in 5.2.1, please upgrade
-
-  bcrypt@5.1.1:
-    resolution: {integrity: sha512-AGBHOG5hPYZ5Xl9KXzU5iKq9516yEmvCKDg3ecP5kX2aB6UqTeXZxk2ELnDgDm6BQSMlLt9rDB4LoSMx0rYwww==}
-    engines: {node: '>= 10.0.0'}
 
   better-path-resolve@1.0.0:
     resolution: {integrity: sha512-pbnl5XzGBdrFU/wT4jqmJVPn2B6UHPBOhzMQkY/SPUPB6QtUXtmBHBIwCbXJol93mOpGMnQyP/+BB19q04xj7g==}
@@ -16102,14 +16095,6 @@ snapshots:
   baseline-browser-mapping@2.10.22: {}
 
   basic-ftp@5.2.0: {}
-
-  bcrypt@5.1.1(encoding@0.1.13):
-    dependencies:
-      '@mapbox/node-pre-gyp': 1.0.11(encoding@0.1.13)
-      node-addon-api: 5.1.0
-    transitivePeerDependencies:
-      - encoding
-      - supports-color
 
   better-path-resolve@1.0.0:
     dependencies:


### PR DESCRIPTION
## Summary
- removes the unused native `bcrypt` devDependency from `@opensourceframework/bcryptjs`
- prunes the corresponding lockfile entries so the bcryptjs workspace no longer pulls the vulnerable `@mapbox/node-pre-gyp > tar@6.2.1` audit path
- adds a patch changeset for the package-health fix

Closes #98

## Tests
- `corepack pnpm@9.6.0 install --frozen-lockfile --ignore-scripts`
- `corepack pnpm@9.6.0 --filter @opensourceframework/bcryptjs test`
- `corepack pnpm@9.6.0 --filter @opensourceframework/bcryptjs lint`
- `corepack pnpm@9.6.0 audit --audit-level high --json` (confirmed 0 bcryptjs-related findings; high count dropped 60 → 54)