### PR TITLE
fix(next-seo): use eslint for example lint script

### DIFF
--- a/packages/next-seo/examples/app-router-showcase/package.json
+++ b/packages/next-seo/examples/app-router-showcase/package.json
@@ -6,7 +6,7 @@
     "dev": "next dev --turbopack",
     "build": "next build",
     "start": "next start",
-    "lint": "next lint"
+    "lint": "eslint ."
   },
   "dependencies": {
     "@opensourceframework/next-seo": "workspace:^",


### PR DESCRIPTION
## Summary
- replaces the removed Next.js `next lint` invocation in the Next SEO app-router example with direct `eslint .`
- restores the package `example:lint`/`test:sweep` path under Next 16

## Tests run
- `corepack pnpm@9.6.0 install --frozen-lockfile`
- `corepack pnpm@9.6.0 --filter @opensourceframework/next-seo example:lint`
- `corepack pnpm@9.6.0 --filter @opensourceframework/next-seo test`
- `corepack pnpm@9.6.0 --filter @opensourceframework/next-seo typecheck`
- `git diff --check`
- staged changed-line secret scan