### PR TITLE
ci(bundle-size): skip browser downloads during install

### DIFF
--- a/.github/workflows/bundle-size.yml
+++ b/.github/workflows/bundle-size.yml
@@ -11,9 +11,15 @@ on:
       - 'docs/**'
       - '**.md'
 
+env:
+  HUSKY: 0
+  PUPPETEER_SKIP_DOWNLOAD: 1
+  PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD: 1
+
 jobs:
   bundle-size:
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - uses: actions/checkout@v4
         with:


### PR DESCRIPTION
## Summary
- Adds the same install-time browser download skips used by CI to the Bundle Size workflow
- Disables Husky during the workflow install
- Caps the bundle-size job at 30 minutes so install regressions fail fast instead of burning the default 6-hour timeout

## Root cause
The Bundle Size workflow's dependency install was cancelled after 6 hours, while the main CI install path completes with browser-download skip env vars. The bundle job was missing those env vars, so install-time browser fetches could stall the workflow.

## Tests
- git diff --check
- Parsed .github/workflows/bundle-size.yml with PyYAML
- Staged secret scan