### PR TITLE
fix(bcryptjs): remove unused native bcrypt dev dependency

### DIFF
--- a/packages/bcryptjs/package.json
+++ b/packages/bcryptjs/package.json
@@ -67,7 +67,6 @@
     "crypto": false
   },
   "devDependencies": {
-    "bcrypt": "^5.1.1",
     "esm2umd": "^0.3.1",
     "prettier": "^3.5.0",
     "typescript": "^5.7.3"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -121,9 +121,6 @@ importers:
 
   packages/bcryptjs:
     devDependencies:
-      bcrypt:
-        specifier: ^5.1.1
-        version: 5.1.1(encoding@0.1.13)
       esm2umd:
         specifier: ^0.3.1
         version: 0.3.1


### PR DESCRIPTION
## Summary
- removes the unused native `bcrypt` devDependency from `@opensourceframework/bcryptjs`
- drops the corresponding importer entry from the lockfile
- reduces high audit findings by removing the vulnerable `tar@6.2.1` path through `@mapbox/node-pre-gyp`

Closes #98

## Tests
- `corepack pnpm@9.6.0 audit --audit-level high --json` (high findings 60 -> 54; tar advisories 6 -> 0)
- `corepack pnpm@9.6.0 install --frozen-lockfile --ignore-scripts`
- `corepack pnpm@9.6.0 --filter @opensourceframework/bcryptjs test`
- `corepack pnpm@9.6.0 --filter @opensourceframework/bcryptjs lint`
- `git diff --check`
- staged changed-line secret scan
