### PR TITLE
fix(showcase): restore ESLint lint script

### DIFF
--- a/showcase/app/page.tsx
+++ b/showcase/app/page.tsx
@@ -1,6 +1,15 @@
-import { ArticleJsonLd, OrganizationJsonLd } from "@opensourceframework/next-seo";
-import { Shield, Lock, Zap, MousePointer2, Image as ImageIcon, Layout, Database, Hash, Accessibility } from "lucide-react";
-import Link from "next/link";
+import { ArticleJsonLd, OrganizationJsonLd } from '@opensourceframework/next-seo';
+import {
+  Shield,
+  Lock,
+  Zap,
+  MousePointer2,
+  Image as ImageIcon,
+  Layout,
+  Database,
+  Hash,
+} from 'lucide-react';
+import Link from 'next/link';
 
 export default function Home() {
   return (
@@ -25,8 +34,8 @@ export default function Home() {
           OpenSource Framework
         </h1>
         <p className="text-xl text-gray-600 max-w-2xl mx-auto">
-          Compatibility-first, modernized forks of the packages you love. 
-          Built for Next.js 16 and React 19.
+          Compatibility-first, modernized forks of the packages you love. Built for Next.js 16 and
+          React 19.
         </p>
       </header>
 
@@ -40,7 +49,10 @@ export default function Home() {
           <p className="text-gray-600 mb-4 text-sm">
             Modernized v3 fork with native OAuth 2.x support and structured URL handling.
           </p>
-          <Link href="/auth-demo" className="text-blue-600 font-medium hover:underline inline-flex items-center gap-1">
+          <Link
+            href="/auth-demo"
+            className="text-blue-600 font-medium hover:underline inline-flex items-center gap-1"
+          >
             Try Auth <MousePointer2 size={14} />
           </Link>
         </section>
@@ -53,7 +65,10 @@ export default function Home() {
           <p className="text-gray-600 mb-4 text-sm">
             App Router compatible CSRF protection with async header/cookie support.
           </p>
-          <Link href="/csrf-demo" className="text-red-600 font-medium hover:underline inline-flex items-center gap-1">
+          <Link
+            href="/csrf-demo"
+            className="text-red-600 font-medium hover:underline inline-flex items-center gap-1"
+          >
             View Security <MousePointer2 size={14} />
           </Link>
         </section>
@@ -67,7 +82,10 @@ export default function Home() {
           <p className="text-gray-600 mb-4 text-sm">
             Optimized critical CSS inlining with improved font preloading.
           </p>
-          <Link href="/seo-preview" className="text-cyan-600 font-medium hover:underline inline-flex items-center gap-1">
+          <Link
+            href="/seo-preview"
+            className="text-cyan-600 font-medium hover:underline inline-flex items-center gap-1"
+          >
             Test SEO <MousePointer2 size={14} />
           </Link>
         </section>
@@ -80,7 +98,10 @@ export default function Home() {
           <p className="text-gray-600 mb-4 text-sm">
             Unified session management supporting both Node.js and Web APIs.
           </p>
-          <Link href="/api/session-info" className="text-green-600 font-medium hover:underline inline-flex items-center gap-1">
+          <Link
+            href="/api/session-info"
+            className="text-green-600 font-medium hover:underline inline-flex items-center gap-1"
+          >
             Check Session <MousePointer2 size={14} />
           </Link>
         </section>
@@ -93,7 +114,10 @@ export default function Home() {
           <p className="text-gray-600 mb-4 text-sm">
             High-performance virtualization for massive datasets on React 18/19.
           </p>
-          <Link href="/virtualization" className="text-cyan-600 font-medium hover:underline inline-flex items-center gap-1">
+          <Link
+            href="/virtualization"
+            className="text-cyan-600 font-medium hover:underline inline-flex items-center gap-1"
+          >
             Run Stress Test <MousePointer2 size={14} />
           </Link>
         </section>

--- a/showcase/app/virtualization/page.tsx
+++ b/showcase/app/virtualization/page.tsx
@@ -1,23 +1,26 @@
-"use client";
+'use client';
 
-import { List, AutoSizer, WindowScroller } from "@opensourceframework/react-virtualized";
-import { Layout, Search, Zap, MousePointer2 } from "lucide-react";
-import Link from "next/link";
-import { useState } from "react";
+import { List, AutoSizer } from '@opensourceframework/react-virtualized';
+import { Zap, MousePointer2 } from 'lucide-react';
+import Link from 'next/link';
 
 // Generate 100,000 items
 const listData = Array.from({ length: 100000 }, (_, index) => ({
   id: index,
   name: `Virtualized Item ${index + 1}`,
   description: `High-performance rendering check for item #${index + 1}.`,
-  color: index % 2 === 0 ? 'bg-white' : 'bg-gray-50'
+  color: index % 2 === 0 ? 'bg-white' : 'bg-gray-50',
 }));
 
 export default function VirtualizationDemo() {
   const rowRenderer = ({ index, isScrolling, key, style }: any) => {
     const item = listData[index];
     return (
-      <div key={key} style={style} className={`flex items-center px-6 border-b border-gray-100 ${item.color}`}>
+      <div
+        key={key}
+        style={style}
+        className={`flex items-center px-6 border-b border-gray-100 ${item.color}`}
+      >
         <div className="flex-1">
           <p className={`font-medium ${isScrolling ? 'text-blue-400' : 'text-gray-900'}`}>
             {item.name}
@@ -32,7 +35,9 @@ export default function VirtualizationDemo() {
   return (
     <main className="min-h-screen p-8 max-w-5xl mx-auto font-sans">
       <nav className="mb-8">
-        <Link href="/" className="text-blue-600 hover:underline">← Back to Showcase</Link>
+        <Link href="/" className="text-blue-600 hover:underline">
+          ← Back to Showcase
+        </Link>
       </nav>
 
       <header className="mb-12">
@@ -41,17 +46,20 @@ export default function VirtualizationDemo() {
           <h1 className="text-3xl font-bold">Virtualization Stress Test</h1>
         </div>
         <p className="text-gray-600">
-          Rendering <strong>100,000 items</strong> smoothly using <strong>@opensourceframework/react-virtualized</strong>. 
-          Verified compatibility with React 19 concurrent mode.
+          Rendering <strong>100,000 items</strong> smoothly using{' '}
+          <strong>@opensourceframework/react-virtualized</strong>. Verified compatibility with React
+          19 concurrent mode.
         </p>
       </header>
 
       <div className="bg-white rounded-3xl shadow-2xl border border-gray-100 overflow-hidden h-[600px] flex flex-col">
         <div className="p-4 bg-gray-50 border-b border-gray-100 flex justify-between items-center text-sm text-gray-500">
           <span>Virtual List (100k Items)</span>
-          <span className="flex items-center gap-1"><MousePointer2 size={14} /> Try scrolling fast</span>
+          <span className="flex items-center gap-1">
+            <MousePointer2 size={14} /> Try scrolling fast
+          </span>
         </div>
-        
+
         <div className="flex-1">
           <AutoSizer>
             {({ height, width }) => (
@@ -71,9 +79,15 @@ export default function VirtualizationDemo() {
       <section className="mt-12 p-6 bg-cyan-50 rounded-2xl border border-cyan-100">
         <h3 className="font-bold text-cyan-900 mb-2">Performance Metrics:</h3>
         <ul className="text-sm text-cyan-800 list-disc list-inside space-y-1">
-          <li><strong>DOM Nodes</strong>: ~20 (vs 100,000 if not virtualized)</li>
-          <li><strong>Memory Pressure</strong>: Constant, regardless of list size</li>
-          <li><strong>Scroll Jitter</strong>: Zero, using optimized overscan</li>
+          <li>
+            <strong>DOM Nodes</strong>: ~20 (vs 100,000 if not virtualized)
+          </li>
+          <li>
+            <strong>Memory Pressure</strong>: Constant, regardless of list size
+          </li>
+          <li>
+            <strong>Scroll Jitter</strong>: Zero, using optimized overscan
+          </li>
         </ul>
       </section>
     </main>

--- a/showcase/package.json
+++ b/showcase/package.json
@@ -6,7 +6,7 @@
     "dev": "next dev",
     "build": "next build --webpack",
     "start": "next start",
-    "lint": "next lint || true"
+    "lint": "eslint ."
   },
   "dependencies": {
     "@opensourceframework/critters": "workspace:*",


### PR DESCRIPTION
## Description
- Replaces the removed `next lint` invocation in the showcase app with `eslint .`.
- Removes unused showcase imports so the restored lint command runs cleanly.
- Formats the touched showcase files with Prettier.

## Related Issue
N/A

## Type of Change
- [x] Bug fix (non-breaking change that fixes an issue)

## Affected Package(s)
- [x] Repository/tooling

## Checklist
- [x] I have read the Contributing Guidelines
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
- [x] Changeset not needed (private showcase/tooling-only change)

## Tests
- `corepack pnpm@9.6.0 --filter showcase lint`
- `corepack pnpm@9.6.0 --filter showcase build`
- `corepack pnpm@9.6.0 lint`
- `corepack pnpm@9.6.0 exec prettier --check showcase/package.json showcase/app/page.tsx showcase/app/virtualization/page.tsx`
- staged secret scan: ok
