### PR TITLE
fix(next-seo): avoid unused NextSeo props

### DIFF
--- a/packages/next-seo/src/components/NextSeo.tsx
+++ b/packages/next-seo/src/components/NextSeo.tsx
@@ -26,14 +26,7 @@ export interface NextSeoProps {
  * Note: In Next.js App Router, it is recommended to use the `generateMetadata` API
  * instead of this component.
  */
-export const NextSeo: React.FC<NextSeoProps> = ({
-  title,
-  description,
-  canonical,
-  openGraph,
-  noindex,
-  nofollow,
-}) => {
+export const NextSeo: React.FC<NextSeoProps> = () => {
   // In App Router, standard meta tags should be handled by generateMetadata.
   // This component is provided for backwards compatibility and transition safety.
   // It doesn't do anything in App Router as tags are managed by Next.js.


### PR DESCRIPTION
## Summary
- Stops destructuring props in the App Router compatibility NextSeo component, preserving the no-op behavior while eliminating six ESLint unused-variable warnings.

## Tests
- corepack pnpm@9.6.0 --filter @opensourceframework/next-seo lint
- corepack pnpm@9.6.0 --filter @opensourceframework/next-seo typecheck
- corepack pnpm@9.6.0 --filter @opensourceframework/next-seo test *(blocked in the isolated worktree because node_modules had to be symlinked from the dirty checkout after a frozen install hit ENOSPC; same command passes in the main checkout before this source-only change)*