### PR TITLE
fix(next-seo): add package license metadata

### DIFF
--- a/.changeset/silver-seals-jam.md
+++ b/.changeset/silver-seals-jam.md
@@ -1,0 +1,5 @@
+---
+"@opensourceframework/next-seo": patch
+---
+
+Add missing MIT license metadata to the published package manifest.

--- a/packages/next-seo/package.json
+++ b/packages/next-seo/package.json
@@ -2,6 +2,7 @@
   "name": "@opensourceframework/next-seo",
   "version": "7.3.6",
   "description": "SEO plugin for Next.js projects",
+  "license": "MIT",
   "sideEffects": false,
   "repository": {
     "type": "git",


### PR DESCRIPTION
## Description
Adds the missing MIT license field to `@opensourceframework/next-seo` package metadata. The package README already documents the original license as MIT, so this makes the published manifest match the documented attribution and other package metadata expectations.

## Related Issue
No linked issue; found during hourly package metadata maintenance.

## Type of Change
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Dependency update
- [ ] Refactoring (no functional changes)

## Affected Package(s)
- [x] @opensourceframework/next-seo
- [ ] Repository/tooling

## Checklist
- [x] I have read the Contributing Guidelines
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have made corresponding changes to the documentation/package metadata
- [x] My changes generate no new warnings
- [x] I have added a changeset for this change

## Tests
- `node -e "const fs=require('fs'); const pkg=JSON.parse(fs.readFileSync('packages/next-seo/package.json','utf8')); if (pkg.license !== 'MIT') process.exit(1); console.log(pkg.name, pkg.license)"`
- `git diff --check`
- staged changed-line secret scan

## Additional Context
`npm pack ./packages/next-seo --dry-run --json` could not complete in the temporary clean worktree because dependencies were not installed and the package prepare script invokes `husky`. A full install in the temporary worktree hit ENOSPC, so validation was limited to manifest parsing and diff checks.