### PR TITLE
fix(critters): remove unused DOM helper

### DIFF
--- a/packages/critters/src/dom.js
+++ b/packages/critters/src/dom.js
@@ -255,20 +255,6 @@ function defineProperties(obj, properties) {
   }
 }
 
-/**
- * Create a property descriptor defining a getter/setter pair alias for a named attribute.
- * @private
- */
-function reflectedProperty(attributeName) {
-  return {
-    get() {
-      return this.getAttribute(attributeName);
-    },
-    set(value) {
-      this.setAttribute(attributeName, value);
-    }
-  };
-}
 
 function cachedQuerySelector(sel, node) {
   const selectorTokens = selectorParser(sel);


### PR DESCRIPTION
## Description
- Removes the dead reflectedProperty helper from Critters DOM utilities.
- Clears the package lint warning without changing runtime behavior.

## Related Issue
N/A

## Type of Change
- [x] Refactoring (no functional changes)

## Affected Package(s)
- [x] @opensourceframework/critters

## Checklist
- [x] I have read the Contributing Guidelines
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
- [x] Changeset not added: no published behavior/API change

## Tests
- corepack pnpm@9.6.0 --filter @opensourceframework/critters lint
- corepack pnpm@9.6.0 --filter @opensourceframework/critters test
- git diff --check
- staged changed-line secret scan