### PR TITLE
fix(showcase): restore lint script

### DIFF
--- a/showcase/package.json
+++ b/showcase/package.json
@@ -6,7 +6,7 @@
     "dev": "next dev",
     "build": "next build --webpack",
     "start": "next start",
-    "lint": "next lint || true"
+    "lint": "eslint ."
   },
   "dependencies": {
     "@opensourceframework/critters": "workspace:*",


### PR DESCRIPTION
## Description
- Replaces the removed `next lint || true` command in the Showcase app with the repo's flat ESLint entrypoint.
- Restores a meaningful Showcase lint check instead of hiding Next 16's `Invalid project directory provided .../showcase/lint` output behind `|| true`.

## Related Issue
None found.

## Type of Change
- [x] Bug fix (non-breaking change that fixes an issue)

## Affected Package(s)
- [x] Repository/tooling

## Checklist
- [x] I have read the Contributing Guidelines / repo instructions
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] New and existing lint checks pass locally with my changes
- [x] Changeset not added: Showcase is a private app/tooling change, not a published package change

## Tests run
- `corepack pnpm@9.6.0 --filter showcase lint` (passes with existing warnings)
- `corepack pnpm@9.6.0 lint`
- `git diff --check`
- staged changed-line secret scan