### PR TITLE
fix(next-seo): silence unused App Router props

### DIFF
--- a/packages/next-seo/src/components/NextSeo.tsx
+++ b/packages/next-seo/src/components/NextSeo.tsx
@@ -26,14 +26,7 @@ export interface NextSeoProps {
  * Note: In Next.js App Router, it is recommended to use the `generateMetadata` API
  * instead of this component.
  */
-export const NextSeo: React.FC<NextSeoProps> = ({
-  title,
-  description,
-  canonical,
-  openGraph,
-  noindex,
-  nofollow,
-}) => {
+export const NextSeo: React.FC<NextSeoProps> = (_props) => {
   // In App Router, standard meta tags should be handled by generateMetadata.
   // This component is provided for backwards compatibility and transition safety.
   // It doesn't do anything in App Router as tags are managed by Next.js.


### PR DESCRIPTION
## Description
- Keeps the App Router compatibility NextSeo component as a no-op while accepting the full props object under an underscore-prefixed parameter.
- Removes the package lint warnings from destructuring intentionally unused SEO props.

## Related Issue
N/A

## Type of Change
- [x] Bug fix (non-breaking change that fixes an issue)

## Affected Package(s)
- [x] @opensourceframework/next-seo

## Checklist
- [x] I have read the Contributing Guidelines
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added a changeset for this change

## Tests run
- `corepack pnpm@9.6.0 --filter @opensourceframework/next-seo lint`
- `corepack pnpm@9.6.0 --filter @opensourceframework/next-seo typecheck`
- `corepack pnpm@9.6.0 --filter @opensourceframework/next-seo test:unit`

## Additional Context
No runtime behavior change; lint is the regression check for this no-op compatibility component.