### PR TITLE
chore: align root pnpm version

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "node": ">=18",
     "pnpm": ">=9"
   },
-  "packageManager": "pnpm@9.0.0",
+  "packageManager": "pnpm@9.6.0",
   "pnpm": {
     "overrides": {
       "@types/react": "^19.0.0",


### PR DESCRIPTION
## Summary
- Updates the root packageManager field from pnpm 9.0.0 to pnpm 9.6.0.
- Matches the pnpm version already required by @opensourceframework/next-iron-session so root-level corepack pnpm commands do not select an incompatible older pnpm.

## Tests
- corepack pnpm@9.6.0 install --frozen-lockfile
- corepack pnpm@9.6.0 --filter @opensourceframework/next-iron-session test
- corepack pnpm@9.6.0 lint
- corepack pnpm --version (reported 9.6.0 after the packageManager update)
- corepack pnpm --filter @opensourceframework/next-iron-session test