### PR TITLE
fix(docs-bot): build CLI before package tests

### DIFF
--- a/packages/docs-bot/package.json
+++ b/packages/docs-bot/package.json
@@ -11,6 +11,8 @@
     "build": "tsup src/index.ts --format cjs,esm --dts --clean",
     "dev": "tsup src/index.ts --format cjs,esm --dts --watch",
     "prepublishOnly": "pnpm build",
+    "pretest": "pnpm build",
+    "pretest:coverage": "pnpm build",
     "test": "vitest run",
     "test:watch": "vitest",
     "test:coverage": "vitest run --coverage"


### PR DESCRIPTION
## Summary
- Adds docs-bot pretest hooks so package-local test commands build the CLI before tests invoke dist/index.js.
- Keeps test:coverage aligned with the same built-CLI requirement.

## Root cause
- docs-bot tests execute node packages/docs-bot/dist/index.js directly, but a fresh package-local pnpm test did not create dist first, causing MODULE_NOT_FOUND.

## Tests
- corepack pnpm@9.6.0 --filter @opensourceframework/docs-bot test
- corepack pnpm@9.6.0 --filter @opensourceframework/docs-bot test:coverage
- git diff --check

## Review
- Self-reviewed the one-file diff and ran a staged changed-line secret scan (ok).