### PR TITLE
fix(next-auth): clear OAuth1 client lint warnings

### DIFF
--- a/packages/next-auth/src/server/lib/oauth/client.js
+++ b/packages/next-auth/src/server/lib/oauth/client.js
@@ -237,15 +237,15 @@ class OAuth1Client {
     this.provider = provider
   }
 
-  async getOAuthRequestToken(params = {}) {
+  async getOAuthRequestToken(_params = {}) {
     throw new Error("OAuth 1.0a is not yet fully implemented in the native client. Please use OAuth 2.0 or contact maintainers.")
   }
 
-  async getOAuthAccessToken(oauth_token, oauth_token_secret, oauth_verifier) {
+  async getOAuthAccessToken(_oauth_token, _oauth_token_secret, _oauth_verifier) {
     throw new Error("OAuth 1.0a is not yet fully implemented in the native client.")
   }
 
-  async get(url, oauth_token, oauth_token_secret) {
+  async get(_url, _oauth_token, _oauth_token_secret) {
     throw new Error("OAuth 1.0a is not yet fully implemented in the native client.")
   }
 }


### PR DESCRIPTION
## Summary
- Prefix intentionally unused OAuth 1.x native-client stub arguments with underscores.
- Keeps the current not-implemented behavior while making the next-auth package lint clean.

## Tests
- corepack pnpm@9.6.0 exec eslint packages/next-auth --ignore-pattern packages/next-auth/examples --no-cache
- corepack pnpm@9.6.0 --filter @opensourceframework/next-auth lint
- corepack pnpm@9.6.0 --filter @opensourceframework/next-auth test