### PR TITLE
docs(sleep-analysis): add package publishing docs

### DIFF
--- a/packages/sleep-analysis/README.md
+++ b/packages/sleep-analysis/README.md
@@ -1,0 +1,49 @@
+# @opensourceframework/sleep-analysis
+
+Biometric sleep data analysis and interpretation utility for TypeScript and JavaScript apps.
+
+## Installation
+
+```bash
+npm install @opensourceframework/sleep-analysis
+# or
+pnpm add @opensourceframework/sleep-analysis
+```
+
+## Usage
+
+```ts
+import { analyzeSleep, type SleepData } from '@opensourceframework/sleep-analysis';
+
+const data: SleepData = {
+  segments: [
+    { startTime: 0, endTime: 60 * 60 * 1000, type: 'light' },
+    { startTime: 60 * 60 * 1000, endTime: 2 * 60 * 60 * 1000, type: 'deep' },
+    { startTime: 2 * 60 * 60 * 1000, endTime: 3 * 60 * 60 * 1000, type: 'rem' },
+    { startTime: 3 * 60 * 60 * 1000, endTime: 200 * 60 * 1000, type: 'awake' },
+  ],
+};
+
+const result = analyzeSleep(data);
+console.log(result.efficiency);
+```
+
+## API
+
+### `analyzeSleep(data)`
+
+Accepts a `SleepData` object containing timestamped sleep-stage segments and returns:
+
+- `totalDurationMinutes`
+- `efficiency`
+- `deepSleepMinutes`
+- `remMinutes`
+- `lightSleepMinutes`
+- `awakeMinutes`
+- `score`
+
+Sleep segment types are `deep`, `rem`, `light`, and `awake`.
+
+## License
+
+MIT

--- a/packages/sleep-analysis/llms.txt
+++ b/packages/sleep-analysis/llms.txt
@@ -1,0 +1,22 @@
+# @opensourceframework/sleep-analysis - AI Summary
+
+Biometric sleep data analysis utility for turning timestamped sleep-stage segments into aggregate duration, efficiency, stage composition, and score metrics. This package is maintained in the OpenSource Framework monorepo as a small TypeScript utility package.
+
+## Maintainer Intent
+
+- Keep the public API compact and predictable for applications that need simple sleep metrics.
+- Preserve low-friction installation and publishing metadata for the package.
+- Prefer clear, deterministic calculations over opaque scoring behavior.
+
+## Installation
+
+```bash
+npm install @opensourceframework/sleep-analysis
+# or
+pnpm add @opensourceframework/sleep-analysis
+```
+
+## Links
+
+- Documentation: https://github.com/riceharvest/opensourceframework/tree/main/packages/sleep-analysis#readme
+- npm: https://www.npmjs.com/package/@opensourceframework/sleep-analysis


### PR DESCRIPTION
## Summary
- Adds the missing sleep-analysis README used by package documentation links
- Adds the llms.txt file already listed in the package publish allowlist
- Verifies the package tarball now includes both docs files

## Tests
- python3 package files check for packages/sleep-analysis
- corepack pnpm@9.6.0 --filter @opensourceframework/sleep-analysis lint
- corepack pnpm@9.6.0 --filter @opensourceframework/sleep-analysis test
- corepack pnpm@9.6.0 --filter @opensourceframework/sleep-analysis build
- npm pack --dry-run