### PR TITLE
fix(tailwindcss-animate): add explicit package exports

### DIFF
--- a/.changeset/tender-llamas-export.md
+++ b/.changeset/tender-llamas-export.md
@@ -1,0 +1,5 @@
+---
+"@opensourceframework/tailwindcss-animate": patch
+---
+
+Add explicit package exports for the plugin entrypoint and package metadata.

--- a/packages/tailwindcss-animate/package.json
+++ b/packages/tailwindcss-animate/package.json
@@ -30,6 +30,13 @@
   "license": "MIT",
   "main": "index.js",
   "types": "index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./index.d.ts",
+      "default": "./index.js"
+    },
+    "./package.json": "./package.json"
+  },
   "files": [
     "index.js",
     "index.d.ts",


### PR DESCRIPTION
## Summary
- Adds an explicit `exports` map for `@opensourceframework/tailwindcss-animate` so modern package resolvers can resolve the root plugin entry and package metadata consistently.
- Adds a patch changeset for the published package metadata change.

## Tests run
- `corepack pnpm@9.6.0 --filter @opensourceframework/tailwindcss-animate test`
- `node -e "const plugin = require('@opensourceframework/tailwindcss-animate'); if (!plugin || typeof plugin !== 'object') throw new Error('missing plugin export'); console.log('require ok')"`
- `node --input-type=module -e "const plugin = await import('@opensourceframework/tailwindcss-animate'); if (!plugin.default) throw new Error('missing default export'); console.log('import ok')"`
- `corepack pnpm@9.6.0 pack --pack-destination /tmp/osf-pack-check` (from package directory)
- `corepack pnpm@9.6.0 exec prettier --check packages/tailwindcss-animate/package.json .changeset/tender-llamas-export.md`
- `git diff --check --cached`
- staged changed-line secret scan