### PR TITLE
fix(bcryptjs): add package homepage metadata

### DIFF
--- a/packages/bcryptjs/package.json
+++ b/packages/bcryptjs/package.json
@@ -18,6 +18,7 @@
   "bugs": {
     "url": "https://github.com/riceharvest/opensourceframework/issues"
   },
+  "homepage": "https://github.com/riceharvest/opensourceframework/tree/main/packages/bcryptjs#readme",
   "keywords": [
     "bcrypt",
     "password",


### PR DESCRIPTION
## Summary
- Adds the missing npm homepage URL for @opensourceframework/bcryptjs.
- Aligns bcryptjs package metadata with the repo-wide package homepage pattern so npm consumers land on this fork's README.

## Tests run
- node -e "JSON.parse(require('fs').readFileSync('packages/bcryptjs/package.json','utf8')); console.log('package json ok')"
- corepack pnpm@9.6.0 --filter @opensourceframework/bcryptjs test
- npm pack --dry-run
- git diff --check
- staged changed-line secret scan

Related: #98