### PR TITLE
fix(deps): patch brace-expansion audit advisories

### DIFF
--- a/package.json
+++ b/package.json
@@ -64,7 +64,10 @@
       "flatted": "^3.4.2",
       "next": ">=16.1.7",
       "ws": ">=8.17.1",
-      "tar-fs": ">=3.1.1"
+      "tar-fs": ">=3.1.1",
+      "brace-expansion@^1.1.7": "1.1.14",
+      "brace-expansion@^2.0.1": "2.1.0",
+      "brace-expansion@^5.0.0": "5.0.6"
     }
   },
   "dependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -15,6 +15,9 @@ overrides:
   next: '>=16.1.7'
   ws: '>=8.17.1'
   tar-fs: '>=3.1.1'
+  brace-expansion@^1.1.7: 1.1.14
+  brace-expansion@^2.0.1: 2.1.0
+  brace-expansion@^5.0.0: 5.0.6
 
 importers:
 
@@ -4949,14 +4952,14 @@ packages:
   boolbase@1.0.0:
     resolution: {integrity: sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww==}
 
-  brace-expansion@1.1.12:
-    resolution: {integrity: sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==}
+  brace-expansion@1.1.14:
+    resolution: {integrity: sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==}
 
-  brace-expansion@2.0.2:
-    resolution: {integrity: sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==}
+  brace-expansion@2.1.0:
+    resolution: {integrity: sha512-TN1kCZAgdgweJhWWpgKYrQaMNHcDULHkWwQIspdtjV4Y5aurRdZpjAqn6yX3FPqTA9ngHCc4hJxMAMgGfve85w==}
 
-  brace-expansion@5.0.3:
-    resolution: {integrity: sha512-fy6KJm2RawA5RcHkLa1z/ScpBeA762UF9KmZQxwIbDtRJrgLzM10depAiEQ+CXYcoiqW1/m96OAAoke2nE9EeA==}
+  brace-expansion@5.0.6:
+    resolution: {integrity: sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==}
     engines: {node: 18 || 20 || >=22}
 
   braces@3.0.3:
@@ -16149,16 +16152,16 @@ snapshots:
 
   boolbase@1.0.0: {}
 
-  brace-expansion@1.1.12:
+  brace-expansion@1.1.14:
     dependencies:
       balanced-match: 1.0.2
       concat-map: 0.0.1
 
-  brace-expansion@2.0.2:
+  brace-expansion@2.1.0:
     dependencies:
       balanced-match: 1.0.2
 
-  brace-expansion@5.0.3:
+  brace-expansion@5.0.6:
     dependencies:
       balanced-match: 4.0.4
 
@@ -20997,20 +21000,20 @@ snapshots:
 
   minimatch@10.2.4:
     dependencies:
-      brace-expansion: 5.0.3
+      brace-expansion: 5.0.6
 
   minimatch@3.1.5:
     dependencies:
-      brace-expansion: 1.1.12
+      brace-expansion: 1.1.14
 
   minimatch@5.1.9:
     dependencies:
-      brace-expansion: 2.0.2
+      brace-expansion: 2.1.0
     optional: true
 
   minimatch@9.0.9:
     dependencies:
-      brace-expansion: 2.0.2
+      brace-expansion: 2.1.0
 
   minimist@1.2.8: {}
 


### PR DESCRIPTION
## Summary
- Add pnpm overrides for patched brace-expansion lines across minimatch consumers
- Refresh the lockfile from brace-expansion 1.1.12/2.0.2/5.0.3 to 1.1.14/2.1.0/5.0.6
- Clears the brace-expansion moderate audit advisory family (4 advisories)

## Tests
- git diff --check
- corepack pnpm@9.6.0 install --frozen-lockfile
- corepack pnpm@9.6.0 audit --audit-level moderate --json (brace-expansion advisories: 0; moderate count 60 -> 56)
- corepack pnpm@9.6.0 --filter '!@opensourceframework/next-iron-session' test

Note: full corepack pnpm@9.6.0 test still hits the existing next-iron-session packageManager mismatch, where nested pnpm resolves as 9.0.0 against packageManager pnpm@9.6.0.