### PR TITLE
fix(deps): raise serialize-javascript audit floor

### DIFF
--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
     "overrides": {
       "@types/react": "^19.0.0",
       "@types/react-dom": "^19.0.0",
-      "serialize-javascript": "^7.0.3",
+      "serialize-javascript": "^7.0.5",
       "undici": "^7.24.0",
       "happy-dom": "^20.8.9",
       "esbuild": "^0.25.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7,7 +7,7 @@ settings:
 overrides:
   '@types/react': ^19.0.0
   '@types/react-dom': ^19.0.0
-  serialize-javascript: ^7.0.3
+  serialize-javascript: ^7.0.5
   undici: ^7.24.0
   happy-dom: ^20.8.9
   esbuild: ^0.25.0
@@ -10108,8 +10108,8 @@ packages:
     engines: {node: '>=10'}
     hasBin: true
 
-  serialize-javascript@7.0.4:
-    resolution: {integrity: sha512-DuGdB+Po43Q5Jxwpzt1lhyFSYKryqoNjQSA9M92tyw0lyHIOur+XCalOUe0KTJpyqzT8+fQ5A0Jf7vCx/NKmIg==}
+  serialize-javascript@7.0.5:
+    resolution: {integrity: sha512-F4LcB0UqUl1zErq+1nYEEzSHJnIwb3AF2XWB94b+afhrekOUijwooAYqFyRbjYkm2PAKBabx6oYv/xDxNi8IBw==}
     engines: {node: '>=20.0.0'}
 
   server-only@0.0.1:
@@ -14339,7 +14339,7 @@ snapshots:
 
   '@rollup/plugin-terser@0.4.4(rollup@2.80.0)':
     dependencies:
-      serialize-javascript: 7.0.4
+      serialize-javascript: 7.0.5
       smob: 1.6.1
       terser: 5.46.0
     optionalDependencies:
@@ -23220,7 +23220,7 @@ snapshots:
       '@babel/code-frame': 7.29.0
       jest-worker: 26.6.2
       rollup: 2.80.0
-      serialize-javascript: 7.0.4
+      serialize-javascript: 7.0.5
       terser: 5.46.0
 
   rollup-plugin-typescript2@0.32.1(rollup@2.80.0)(typescript@4.9.5):
@@ -23394,7 +23394,7 @@ snapshots:
   semver@7.8.1:
     optional: true
 
-  serialize-javascript@7.0.4: {}
+  serialize-javascript@7.0.5: {}
 
   server-only@0.0.1: {}
 


### PR DESCRIPTION
## Summary
- Raises the root pnpm override for serialize-javascript from ^7.0.3 to ^7.0.5.
- Refreshes pnpm-lock so @rollup/plugin-terser consumers resolve the patched 7.0.5 release.
- Removes the serialize-javascript moderate CPU-exhaustion advisory from the production audit output.

## Tests
- corepack pnpm@9.6.0 install --frozen-lockfile --prefer-offline
- corepack pnpm@9.6.0 --filter @opensourceframework/next-pwa test
- corepack pnpm@9.6.0 --filter @opensourceframework/next-pwa build
- corepack pnpm@9.6.0 audit --audit-level moderate --prod --json (serialize-javascript no longer present; remaining audit findings pre-existing)