### PR TITLE
test(next-optimized-images): isolate loader detection test

### DIFF
--- a/packages/next-optimized-images/__tests__/loaders/index.test.js
+++ b/packages/next-optimized-images/__tests__/loaders/index.test.js
@@ -6,11 +6,21 @@ const {
   appendLoaders,
 } = require('../../lib/loaders');
 const { getConfig } = require('../../lib/config');
-const fs = require('fs');
-const os = require('os');
+const Module = require('module');
 const path = require('path');
 
 const imageminPluginPath = path.join(__dirname, '../fixtures/imagemin-plugin.js');
+const optionalLoaderNames = new Set([
+  'imagemin-mozjpeg',
+  'imagemin-gifsicle',
+  'imagemin-svgo',
+  'svg-sprite-loader',
+  'webp-loader',
+  'lqip-loader',
+  'imagemin-optipng',
+  'imagemin-pngquant',
+  'responsive-loader',
+]);
 
 describe('next-optimized-images/loaders', () => {
   it('detects if a module is installed', () => {
@@ -21,10 +31,21 @@ describe('next-optimized-images/loaders', () => {
   });
 
   it('detects installed loaders', () => {
-    const emptyResolvePath = fs.mkdtempSync(path.join(os.tmpdir(), 'next-optimized-images-'));
+    const originalResolveFilename = Module._resolveFilename;
+    const resolveSpy = vi.spyOn(Module, '_resolveFilename').mockImplementation(function (...args) {
+      const [request] = args;
+
+      if (optionalLoaderNames.has(request)) {
+        const error = new Error(`Cannot find module '${request}'`);
+        error.code = 'MODULE_NOT_FOUND';
+        throw error;
+      }
+
+      return originalResolveFilename.apply(this, args);
+    });
 
     try {
-      expect(detectLoaders(emptyResolvePath)).toEqual({
+      expect(detectLoaders()).toEqual({
         jpeg: false,
         gif: false,
         svg: false,
@@ -36,7 +57,7 @@ describe('next-optimized-images/loaders', () => {
         responsiveAdapter: false,
       });
     } finally {
-      fs.rmSync(emptyResolvePath, { recursive: true, force: true });
+      resolveSpy.mockRestore();
     }
   });
 


### PR DESCRIPTION
## Summary
- Makes the next-optimized-images loader detection test independent of ambient optional loaders discoverable through Node's module resolution.
- Replaces the temporary empty directory assumption with a mocked module resolver for optional image loaders.

## Root Cause
The test created an empty directory under the system temp directory and expected optional loaders to be absent. Node still walks ancestor node_modules directories, so an ambient /tmp/node_modules/svg-sprite-loader can make detectLoaders return "svg-sprite-loader" and fail the suite.

## Tests
- corepack pnpm@9.6.0 --filter @opensourceframework/next-optimized-images test
- corepack pnpm@9.6.0 --filter @opensourceframework/next-optimized-images lint
- regression check with a temporary /tmp/node_modules/svg-sprite-loader stub plus the package test script
- git diff --check

Note: the repository pre-commit hook runs `vitest related --run` without the package's `--globals` flag, which fails existing CommonJS/global-style tests with `describe is not defined`; the package-local test script above passes.