### PR TITLE
fix(docs-bot): use tracked CLI bin shim

### DIFF
--- a/packages/docs-bot/bin/docs-bot.cjs
+++ b/packages/docs-bot/bin/docs-bot.cjs
@@ -1,0 +1,25 @@
+#!/usr/bin/env node
+
+const path = require('node:path');
+const fs = require('node:fs');
+const { spawnSync } = require('node:child_process');
+
+const entrypoint = path.join(__dirname, '..', 'dist', 'index.js');
+
+if (!fs.existsSync(entrypoint)) {
+  console.error(
+    'The @opensourceframework/docs-bot CLI has not been built yet. Run `pnpm --filter @opensourceframework/docs-bot build` first.'
+  );
+  process.exit(1);
+}
+
+const result = spawnSync(process.execPath, [entrypoint, ...process.argv.slice(2)], {
+  stdio: 'inherit',
+});
+
+if (result.error) {
+  console.error(result.error.message);
+  process.exit(1);
+}
+
+process.exit(result.status ?? 0);

--- a/packages/docs-bot/package.json
+++ b/packages/docs-bot/package.json
@@ -5,7 +5,7 @@
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "bin": {
-    "docs-bot": "./dist/index.js"
+    "docs-bot": "./bin/docs-bot.cjs"
   },
   "scripts": {
     "build": "tsup src/index.ts --format cjs,esm --dts --clean",
@@ -18,6 +18,7 @@
     "test:coverage": "vitest run --coverage"
   },
   "files": [
+    "bin",
     "dist"
   ],
   "keywords": [


### PR DESCRIPTION
## Description

Fixes the docs-bot workspace bin metadata so fresh installs no longer warn that `node_modules/.bin/docs-bot` points at missing `dist/index.js` before the package is built. The published CLI now points at a tracked shim that delegates to the built entrypoint and gives a clear build-first error if dist is missing.

## Related Issue

N/A

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Affected Package(s)

- [x] Repository/tooling
- [x] @opensourceframework/docs-bot

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
- [ ] I have added a changeset for this change (not added: package is still 0.0.1/internal tooling and this only fixes packaging metadata)

## Tests run

- `corepack pnpm@9.6.0 install --frozen-lockfile` (verified no `Failed to create bin at ... docs-bot` warning)
- `corepack pnpm@9.6.0 --filter @opensourceframework/docs-bot test`
- `corepack pnpm@9.6.0 --filter @opensourceframework/docs-bot build`
- `node packages/docs-bot/bin/docs-bot.cjs --help`
- `corepack pnpm@9.6.0 pack --pack-destination /tmp/osf-maint-pack` from `packages/docs-bot`
- `git diff --check`
- staged secret scan
