### PR TITLE
fix(next-csrf): remove stub cookie types

### DIFF
--- a/packages/next-csrf/package.json
+++ b/packages/next-csrf/package.json
@@ -46,7 +46,6 @@
     "clean": "rm -rf dist coverage node_modules"
   },
   "devDependencies": {
-    "@types/cookie": "^1.0.0",
     "@types/cookie-signature": "^1.1.2",
     "@types/csrf": "^3.1.3",
     "@types/node": "^22.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -543,9 +543,6 @@ importers:
         specifier: '>=18.2.0 <22.0.0 || ^19.0.0'
         version: 19.2.4(react@19.2.4)
     devDependencies:
-      '@types/cookie':
-        specifier: ^1.0.0
-        version: 1.0.0
       '@types/cookie-signature':
         specifier: ^1.1.2
         version: 1.1.2
@@ -4001,10 +3998,6 @@ packages:
 
   '@types/cookie@0.6.0':
     resolution: {integrity: sha512-4Kh9a6B2bQciAhf7FSuMRRkUWecJgJu9nPnx3yzpsfXX/c50REIqpHY4C82bXP90qrLtXtkDxTZosYO3UpOwlA==}
-
-  '@types/cookie@1.0.0':
-    resolution: {integrity: sha512-mGFXbkDQJ6kAXByHS7QAggRXgols0mAdP4MuXgloGY1tXokvzaFFM4SMqWvf7AH0oafI7zlFJwoGWzmhDqTZ9w==}
-    deprecated: This is a stub types definition. cookie provides its own type definitions, so you do not need this installed.
 
   '@types/csrf@3.1.3':
     resolution: {integrity: sha512-87/Vuivr3u5Yzd5Rx5aCeQyz4pCCFuCTwv92qLfuW9vd4yRJvWwSRR14Uc8yEc2Qnp16EAP6hDhd3XANCSxhWA==}
@@ -14729,10 +14722,6 @@ snapshots:
   '@types/cookie@0.4.1': {}
 
   '@types/cookie@0.6.0': {}
-
-  '@types/cookie@1.0.0':
-    dependencies:
-      cookie: 1.1.1
 
   '@types/csrf@3.1.3':
     dependencies:


### PR DESCRIPTION
## Summary
- removes the deprecated @types/cookie stub from next-csrf
- lets TypeScript use cookie@1.1.1's bundled SerializeOptions export during DTS builds
- updates the lockfile to drop the unused stub package

## Root cause
The next-csrf DTS build imported SerializeOptions from cookie, but the package also installed @types/cookie@1.0.0. That @types package is only a deprecated stub and can shadow cookie's bundled declarations, causing tsup's declaration build to report that SerializeOptions is not exported.

## Tests
- corepack pnpm@9.6.0 --filter @opensourceframework/next-csrf build
- corepack pnpm@9.6.0 --filter @opensourceframework/next-csrf test
- corepack pnpm@9.6.0 test (next-csrf passed; later failed in showcase#build because webpack is not installed/resolvable in this worktree)
- git diff --check
- staged changed-line secret scan