### PR TITLE
fix(react-virtualized): restore published stylesheet

### DIFF
--- a/.changeset/react-virtualized-styles.md
+++ b/.changeset/react-virtualized-styles.md
@@ -1,0 +1,5 @@
+---
+'@opensourceframework/react-virtualized': patch
+---
+
+Restore the documented `styles.css` file in the published package.

--- a/packages/react-virtualized/.gitignore
+++ b/packages/react-virtualized/.gitignore
@@ -4,6 +4,5 @@ coverage
 dist
 node_modules
 npm-debug.log
-styles.css
 .vscode
 .idea

--- a/packages/react-virtualized/styles.css
+++ b/packages/react-virtualized/styles.css
@@ -1,0 +1,82 @@
+/* Collection default theme */
+
+.ReactVirtualized__Collection {
+}
+
+.ReactVirtualized__Collection__innerScrollContainer {
+}
+
+/* Grid default theme */
+
+.ReactVirtualized__Grid {
+}
+
+.ReactVirtualized__Grid__innerScrollContainer {
+}
+
+/* Table default theme */
+
+.ReactVirtualized__Table {
+}
+
+.ReactVirtualized__Table__Grid {
+}
+
+.ReactVirtualized__Table__headerRow {
+  font-weight: 700;
+  text-transform: uppercase;
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+}
+
+.ReactVirtualized__Table__row {
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+}
+
+.ReactVirtualized__Table__headerTruncatedText {
+  display: inline-block;
+  max-width: 100%;
+  white-space: nowrap;
+  text-overflow: ellipsis;
+  overflow: hidden;
+}
+
+.ReactVirtualized__Table__headerColumn,
+.ReactVirtualized__Table__rowColumn {
+  margin-right: 10px;
+  min-width: 0px;
+}
+
+.ReactVirtualized__Table__rowColumn {
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.ReactVirtualized__Table__headerColumn:first-of-type,
+.ReactVirtualized__Table__rowColumn:first-of-type {
+  margin-left: 10px;
+}
+
+.ReactVirtualized__Table__sortableHeaderColumn {
+  cursor: pointer;
+}
+
+.ReactVirtualized__Table__sortableHeaderIconContainer {
+  display: flex;
+  align-items: center;
+}
+
+.ReactVirtualized__Table__sortableHeaderIcon {
+  flex: 0 0 24px;
+  height: 1em;
+  width: 1em;
+  fill: currentColor;
+}
+
+/* List default theme */
+
+.ReactVirtualized__List {
+}

--- a/packages/react-virtualized/test/index.test.ts
+++ b/packages/react-virtualized/test/index.test.ts
@@ -1,4 +1,7 @@
+import { access } from 'node:fs/promises';
+import { join } from 'node:path';
 import { describe, expect, it } from 'vitest';
+import packageJson from '../package.json';
 import * as reactVirtualized from '../source-stripped/index.jsx';
 
 describe('@opensourceframework/react-virtualized', () => {
@@ -7,5 +10,10 @@ describe('@opensourceframework/react-virtualized', () => {
     expect(reactVirtualized).toHaveProperty('Grid');
     expect(reactVirtualized).toHaveProperty('List');
     expect(reactVirtualized).toHaveProperty('Table');
+  });
+
+  it('ships the documented stylesheet', async () => {
+    expect(packageJson.files).toContain('styles.css');
+    await expect(access(join(__dirname, '..', 'styles.css'))).resolves.toBeUndefined();
   });
 });


### PR DESCRIPTION
## Summary
- Restores the documented `react-virtualized/styles.css` entry so npm packages include it again.
- Removes the stale package-local ignore rule for the stylesheet.
- Adds a regression test that checks the stylesheet remains present while listed in package files.
- Adds a patch changeset for `@opensourceframework/react-virtualized`.

## Tests
- `git diff --check`
- `corepack pnpm@9.6.0 --filter @opensourceframework/react-virtualized build`
- `corepack pnpm@9.6.0 --filter @opensourceframework/react-virtualized test`
- `corepack pnpm@9.6.0 --filter @opensourceframework/react-virtualized lint`
- `corepack pnpm@9.6.0 --filter @opensourceframework/react-virtualized typecheck`
- `npm pack --dry-run --json` (verified `styles.css` included)