### PR TITLE
fix(next-csrf): stabilize cookie option types

### DIFF
--- a/.changeset/next-csrf-cookie-options.md
+++ b/.changeset/next-csrf-cookie-options.md
@@ -1,0 +1,5 @@
+---
+"@opensourceframework/next-csrf": patch
+---
+
+Keep cookie option types local so declaration builds do not depend on the cookie package's exported type alias name.

--- a/packages/next-csrf/src/index.ts
+++ b/packages/next-csrf/src/index.ts
@@ -11,15 +11,14 @@
  * Synchronizer Token Pattern.
  */
 
-import type { SerializeOptions } from 'cookie';
 import type { NextApiHandler } from 'next';
 import { csrf, setup } from './middleware';
-import type { Middleware, NextCSRF, NextCsrfOptions } from './types';
+import type { CookieOptions, Middleware, NextCSRF, NextCsrfOptions } from './types';
 
 /**
  * Default cookie options for CSRF cookies
  */
-const cookieDefaultOptions: SerializeOptions = {
+const cookieDefaultOptions: CookieOptions = {
   httpOnly: false,
   path: '/',
   sameSite: 'lax',

--- a/packages/next-csrf/src/types.ts
+++ b/packages/next-csrf/src/types.ts
@@ -7,7 +7,26 @@
  * @license MIT
  */
 
-import type { SerializeOptions } from 'cookie';
+/**
+ * Cookie serialization options accepted by the underlying `cookie` package.
+ *
+ * Keep this local instead of importing the type from `cookie`: supported cookie
+ * versions expose this shape under different names (`SerializeOptions` in 1.x,
+ * `CookieSerializeOptions` in the DefinitelyTyped 0.x types), but the runtime
+ * option contract is the same for the fields we expose publicly.
+ */
+export interface CookieOptions {
+  domain?: string;
+  encode?: (value: string) => string;
+  expires?: Date;
+  httpOnly?: boolean;
+  maxAge?: number;
+  partitioned?: boolean;
+  path?: string;
+  priority?: 'low' | 'medium' | 'high';
+  sameSite?: boolean | 'lax' | 'strict' | 'none';
+  secure?: boolean;
+}
 
 /**
  * Configuration options for the nextCsrf function
@@ -43,7 +62,7 @@ export interface NextCsrfOptions {
    * Important: The sameSite: 'lax' setting provides additional CSRF protection by
    * preventing cookies from being sent with cross-site POST requests.
    */
-  cookieOptions?: SerializeOptions;
+  cookieOptions?: CookieOptions;
   /** Secret key for signing cookies. Optional but recommended for production. */
   secret?: string;
   /**
@@ -61,7 +80,7 @@ export interface NextCsrfOptions {
  * Extends NextCsrfOptions with required fields
  */
 export interface MiddlewareArgs extends Required<Omit<NextCsrfOptions, 'secret'>> {
-  cookieOptions: SerializeOptions;
+  cookieOptions: CookieOptions;
   secret?: string;
 }
 
@@ -70,7 +89,7 @@ export interface MiddlewareArgs extends Required<Omit<NextCsrfOptions, 'secret'>
  */
 export interface SetupMiddlewareArgs {
   tokenKey: string;
-  cookieOptions: SerializeOptions;
+  cookieOptions: CookieOptions;
   secret?: string;
 }
 


### PR DESCRIPTION
## Summary
- replaces the public next-csrf cookie option type import with a local CookieOptions interface
- avoids declaration/typecheck failures when the installed cookie typings expose the serialize options under a different alias
- adds a patch changeset for @opensourceframework/next-csrf

## Root cause
The next-csrf declarations imported `SerializeOptions` directly from `cookie`. That alias exists in cookie 1.x's bundled types, but local/tooling installs can resolve older DefinitelyTyped cookie declarations that name the same runtime shape `CookieSerializeOptions`, causing `tsc`/tsup DTS builds to fail before package tests run.

## Tests
- `corepack pnpm@9.6.0 --filter @opensourceframework/next-csrf typecheck`
- `corepack pnpm@9.6.0 --filter @opensourceframework/next-csrf build`
- `corepack pnpm@9.6.0 --filter @opensourceframework/next-csrf test`
- `corepack pnpm@9.6.0 --filter @opensourceframework/next-csrf lint`