### PR TITLE
chore: align root workspace manifest

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,9 @@
   "description": "OpenSourceFramework - A collection of maintained Next.js packages",
   "workspaces": [
     "packages/*",
-    "tools/*"
+    "tools/*",
+    "docs",
+    "showcase"
   ],
   "scripts": {
     "prepare": "husky install",


### PR DESCRIPTION
## Summary
- Adds the docs and showcase workspaces to the root package.json workspace list
- Keeps package.json aligned with pnpm-workspace.yaml so non-pnpm workspace tooling sees the same projects

## Tests
- corepack pnpm@9.6.0 exec prettier --check package.json pnpm-workspace.yaml
- git diff --check
- corepack pnpm@9.6.0 -r list --depth=-1

## Notes
- Full pnpm test was probed separately on current main and still exposes an existing next-seo React-instance failure; this PR only changes workspace metadata.