### PR TITLE
ci: fix optional Snyk check in security audit

### DIFF
--- a/.github/workflows/security-audit.yml
+++ b/.github/workflows/security-audit.yml
@@ -43,14 +43,25 @@ jobs:
       - name: Run npm audit
         run: pnpm audit --audit-level=moderate
 
+      - name: Check Snyk configuration
+        id: snyk
+        env:
+          SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
+        run: |
+          if [ -n "$SNYK_TOKEN" ]; then
+            echo "configured=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "configured=false" >> "$GITHUB_OUTPUT"
+          fi
+
       - name: Run Snyk Security Scan
-        if: ${{ secrets.SNYK_TOKEN != '' }}
+        if: ${{ steps.snyk.outputs.configured == 'true' }}
         uses: snyk/actions/node@master
         env:
           SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
 
       - name: Report missing Snyk configuration
-        if: ${{ secrets.SNYK_TOKEN == '' }}
+        if: ${{ steps.snyk.outputs.configured == 'false' }}
         run: echo "Snyk scan skipped because SNYK_TOKEN is not configured." >> $GITHUB_STEP_SUMMARY
 
       - name: Generate Security Report


### PR DESCRIPTION
## Summary
- Fixes the security-audit workflow parse failure caused by referencing the secrets context directly in step-level if expressions.
- Adds a Snyk configuration probe step and gates the optional Snyk scan/reporting on that step output.

## Root cause
Recent main pushes showed the Security Audit workflow failing immediately with zero jobs created. The workflow used secrets.SNYK_TOKEN directly in if conditions, which GitHub Actions does not allow for condition evaluation; moving the check into a runtime step output keeps the optional behavior without invalid workflow syntax.

## Tests
- corepack pnpm@9.6.0 exec prettier --check .github/workflows/security-audit.yml
- python3 yaml.safe_load(.github/workflows/security-audit.yml)
- go run github.com/rhysd/actionlint/cmd/actionlint@latest .github/workflows/security-audit.yml
- corepack pnpm@9.6.0 audit --audit-level moderate --json (0 vulnerabilities)
- corepack pnpm@9.6.0 test
- corepack pnpm@9.6.0 lint
- corepack pnpm@9.6.0 typecheck