### PR TITLE
test(next-optimized-images): scope coverage to runtime files

### DIFF
--- a/packages/next-optimized-images/vitest.config.js
+++ b/packages/next-optimized-images/vitest.config.js
@@ -1,0 +1,15 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    environment: 'node',
+    globals: true,
+    include: ['__tests__/**/*.test.js'],
+    coverage: {
+      provider: 'v8',
+      reporter: ['text', 'json', 'html'],
+      include: ['lib/**'],
+      exclude: ['lib/**/__tests__/**'],
+    },
+  },
+});


### PR DESCRIPTION
## Summary
- Adds a package-local Vitest config for @opensourceframework/next-optimized-images.
- Restricts coverage instrumentation to runtime lib files so examples no longer drag the package coverage report below 80%.
- Keeps the existing JS test glob and node environment explicit for package-local test runs.

## Tests
- corepack pnpm@9.6.0 --filter @opensourceframework/next-optimized-images test:coverage
- corepack pnpm@9.6.0 --filter @opensourceframework/next-optimized-images test
- corepack pnpm@9.6.0 --filter @opensourceframework/next-optimized-images lint
- corepack pnpm@9.6.0 --filter @opensourceframework/next-optimized-images build
- git diff --cached --check
- staged secret scan