### PR TITLE
fix(next-optimized-images): externalize loader helpers in build

### DIFF
--- a/packages/next-optimized-images/tsup.config.ts
+++ b/packages/next-optimized-images/tsup.config.ts
@@ -5,5 +5,11 @@ export default defineConfig({
   format: ['cjs', 'esm'],
   dts: true,
   clean: true,
-  external: ['next', 'webpack'],
+  external: [
+    'next',
+    'webpack',
+    './loaders/raw-loader/export-loader.js',
+    './loaders/lqip-loader/picture-export-loader.js',
+    './loaders/lqip-loader/colors-export-loader.js',
+  ],
 })


### PR DESCRIPTION
## Summary
- Marks loader helper modules used via require.resolve as tsup externals.
- Removes esbuild/tsup build warnings while preserving the copied loader files in dist.

## Tests
- corepack pnpm@9.6.0 --filter @opensourceframework/next-optimized-images build (verified no 'should be marked as external' warnings)
- corepack pnpm@9.6.0 --filter @opensourceframework/next-optimized-images test
- corepack pnpm@9.6.0 --filter @opensourceframework/next-optimized-images lint
- corepack pnpm@9.6.0 test
- corepack pnpm@9.6.0 lint
- corepack pnpm@9.6.0 audit --audit-level moderate --json

No changeset: build-tooling-only cleanup, no package runtime/API change.