### PR TITLE
fix(showcase): suppress demo next-auth URL warning

### DIFF
--- a/showcase/app/api/auth/[...nextauth]/route.ts
+++ b/showcase/app/api/auth/[...nextauth]/route.ts
@@ -1,5 +1,7 @@
-import NextAuth from "@opensourceframework/next-auth";
-import Providers from "@opensourceframework/next-auth/providers";
+process.env.NEXTAUTH_URL ||= "http://localhost:3000";
+
+const NextAuth = require("@opensourceframework/next-auth");
+const Providers = require("@opensourceframework/next-auth/providers");
 
 const handler = NextAuth({
   providers: [


### PR DESCRIPTION
## Summary
- Sets a local NEXTAUTH_URL before importing the showcase NextAuth route dependencies.
- Keeps the demo build clean without requiring developers to configure an env file just to build the showcase.

## Tests
- corepack pnpm@9.6.0 --filter showcase build (verified NEXTAUTH_URL warning is gone)
- corepack pnpm@9.6.0 --filter showcase lint
- git diff --check
- staged secret scan