### PR TITLE
chore: align root Node engine with Next

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "vitest": "^2.1.9"
   },
   "engines": {
-    "node": ">=18",
+    "node": ">=20.9.0",
     "pnpm": ">=9"
   },
   "packageManager": "pnpm@9.6.0",


### PR DESCRIPTION
## Summary
- updates the private root workspace engine from Node >=18 to >=20.9.0
- matches the installed Next.js 16 engine requirement so contributors fail fast on unsupported Node versions

## Tests
- git diff --check
- corepack pnpm@9.6.0 install --frozen-lockfile
- corepack pnpm@9.6.0 lint
- corepack pnpm@9.6.0 typecheck

## Notes
- package-local published package engines are unchanged