### PR TITLE
fix(next-mdx): preserve root shims in package files cleanup

### DIFF
--- a/.changeset/clean-mdx-package-files.md
+++ b/.changeset/clean-mdx-package-files.md
@@ -1,0 +1,6 @@
+---
+"@opensourceframework/next-mdx": patch
+"@opensourceframework/next-mdx-toc": patch
+---
+
+Remove stale non-existent root entry files from the published package file lists.

--- a/.changeset/clean-mdx-package-files.md
+++ b/.changeset/clean-mdx-package-files.md
@@ -1,6 +1,5 @@
 ---
-"@opensourceframework/next-mdx": patch
 "@opensourceframework/next-mdx-toc": patch
 ---
 
-Remove stale non-existent root entry files from the published package file lists.
+Remove stale non-existent root entry files from the `@opensourceframework/next-mdx-toc` published package file list.

--- a/packages/next-mdx-toc/package.json
+++ b/packages/next-mdx-toc/package.json
@@ -20,8 +20,6 @@
   },
   "files": [
     "dist",
-    "index.js",
-    "index.d.ts",
     "llms.txt"
   ],
   "bugs": {

--- a/packages/next-mdx/package.json
+++ b/packages/next-mdx/package.json
@@ -19,6 +19,10 @@
   },
   "files": [
     "dist",
+    "server.js",
+    "server.d.ts",
+    "client.js",
+    "client.d.ts",
     "llms.txt"
   ],
   "bugs": {

--- a/packages/next-mdx/package.json
+++ b/packages/next-mdx/package.json
@@ -19,10 +19,6 @@
   },
   "files": [
     "dist",
-    "server.js",
-    "server.d.ts",
-    "client.js",
-    "client.d.ts",
     "llms.txt"
   ],
   "bugs": {


### PR DESCRIPTION
## Summary
- Keeps the tracked root `server`/`client` shim files in `@opensourceframework/next-mdx`'s published package allowlist so subpath/legacy entrypoints stay available
- Removes only the non-existent root `index.js`/`index.d.ts` entries from `@opensourceframework/next-mdx-toc`
- Narrows the changeset to `@opensourceframework/next-mdx-toc` because `@opensourceframework/next-mdx` no longer changes package contents

## Tests
- `git diff --check`
- `corepack pnpm@9.6.0 --filter @opensourceframework/next-mdx build`
- `corepack pnpm@9.6.0 --filter @opensourceframework/next-mdx-toc build`
- `corepack pnpm@9.6.0 --filter @opensourceframework/next-mdx test`
- `corepack pnpm@9.6.0 --filter @opensourceframework/next-mdx-toc test`
- `npm pack --dry-run --ignore-scripts --json ./packages/next-mdx`
- `npm pack --dry-run --ignore-scripts --json ./packages/next-mdx-toc`
