### PR TITLE
docs: align setup requirements with pinned pnpm

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -21,8 +21,8 @@ This project follows the [Contributor Covenant Code of Conduct](./CODE_OF_CONDUC
 
 ### Prerequisites
 
-- **Node.js**: Version 20.0.0 or higher
-- **pnpm**: Version 9.0.0 or higher
+- **Node.js**: Version 20.9.0 or higher
+- **pnpm**: Version 9.6.0 via Corepack
 - **Git**: For version control
 
 ### Initial Setup
@@ -35,14 +35,14 @@ This project follows the [Contributor Covenant Code of Conduct](./CODE_OF_CONDUC
 
 2. **Install dependencies**
    ```bash
-   pnpm install
+   corepack pnpm@9.6.0 install
    ```
 
 3. **Verify setup**
    ```bash
-   pnpm build
-   pnpm test
-   pnpm lint
+   corepack pnpm@9.6.0 build
+   corepack pnpm@9.6.0 test
+   corepack pnpm@9.6.0 lint
    ```
 
 ### IDE Setup

--- a/README.md
+++ b/README.md
@@ -141,8 +141,8 @@ We welcome contributions! Please see our [Contributing Guide](./CONTRIBUTING.md)
 
 ### Prerequisites
 
-- Node.js 18+
-- pnpm 9+
+- Node.js 20.9+
+- pnpm 9.6.0 via Corepack
 
 ### Setup
 
@@ -152,16 +152,16 @@ git clone https://github.com/riceharvest/opensourceframework.git
 cd opensourceframework
 
 # Install dependencies
-pnpm install
+corepack pnpm@9.6.0 install
 
 # Build all packages
-pnpm build
+corepack pnpm@9.6.0 build
 
 # Run tests
-pnpm test
+corepack pnpm@9.6.0 test
 
 # Lint code
-pnpm lint
+corepack pnpm@9.6.0 lint
 ```
 
 ## License

--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
   },
   "engines": {
     "node": ">=20.9.0",
-    "pnpm": ">=9"
+    "pnpm": ">=9.6.0"
   },
   "packageManager": "pnpm@9.6.0",
   "pnpm": {


### PR DESCRIPTION
## Summary
- Tightens the root pnpm engine to match the pinned package manager version.
- Updates README and CONTRIBUTING setup commands to use Corepack with pnpm 9.6.0.
- Aligns documented Node requirement with the repo engine (Node 20.9+).

## Tests run
- git diff --check
- corepack pnpm@9.6.0 exec prettier --check README.md CONTRIBUTING.md package.json
- corepack pnpm@9.6.0 install --frozen-lockfile
- corepack pnpm@9.6.0 typecheck
- corepack pnpm@9.6.0 --filter @opensourceframework/next-optimized-images test
- corepack pnpm@9.6.0 test
- corepack pnpm@9.6.0 lint