### PR TITLE
fix(next-mdx-toc): use Corepack for workspace prebuild

### DIFF
--- a/.changeset/curly-shoes-bake.md
+++ b/.changeset/curly-shoes-bake.md
@@ -1,0 +1,5 @@
+---
+"@opensourceframework/next-mdx-toc": patch
+---
+
+Use Corepack for the package prebuild/predev workspace dependency build so the repo-pinned pnpm version is used even when the shell has an older pnpm on PATH.

--- a/packages/next-mdx-toc/package.json
+++ b/packages/next-mdx-toc/package.json
@@ -15,8 +15,8 @@
     "test": "vitest run",
     "build": "tsup",
     "dev": "tsup --watch",
-    "prebuild": "pnpm --filter @opensourceframework/next-mdx build",
-    "predev": "pnpm --filter @opensourceframework/next-mdx build"
+    "prebuild": "corepack pnpm --filter @opensourceframework/next-mdx build",
+    "predev": "corepack pnpm --filter @opensourceframework/next-mdx build"
   },
   "files": [
     "dist",

--- a/packages/next-mdx-toc/test/package-scripts.test.js
+++ b/packages/next-mdx-toc/test/package-scripts.test.js
@@ -1,0 +1,13 @@
+import { describe, expect, it } from 'vitest';
+import packageJson from '../package.json' assert { type: 'json' };
+
+describe('package scripts', () => {
+  it('uses the repo-pinned pnpm through Corepack for workspace dependency builds', () => {
+    expect(packageJson.scripts.prebuild).toBe(
+      'corepack pnpm --filter @opensourceframework/next-mdx build'
+    );
+    expect(packageJson.scripts.predev).toBe(
+      'corepack pnpm --filter @opensourceframework/next-mdx build'
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- changes next-mdx-toc prebuild/predev to invoke the repo-pinned pnpm through Corepack
- adds a package-script regression test and changeset

## Root Cause
Running `corepack pnpm@9.6.0 test` still failed when next-mdx-toc's prebuild shell command called the older `pnpm` binary on PATH (9.0.0), tripping the root `engines.pnpm >=9.6.0` check.

## Tests
- `corepack pnpm@9.6.0 --filter @opensourceframework/next-mdx-toc test`
- `corepack pnpm@9.6.0 --filter @opensourceframework/next-mdx-toc build`
- `corepack pnpm@9.6.0 test`
- `corepack pnpm@9.6.0 prettier --check .changeset/curly-shoes-bake.md packages/next-mdx-toc/package.json packages/next-mdx-toc/test/package-scripts.test.js`
- `git diff --check`