### PR TITLE
ci: use workspace pnpm in lockfile resolver

### DIFF
--- a/.github/workflows/resolve-lockfile.yml
+++ b/.github/workflows/resolve-lockfile.yml
@@ -43,8 +43,8 @@ jobs:
         with:
           node-version: 20
 
-      - name: Install pnpm
-        run: npm install -g pnpm@9
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
 
       - name: Resolve conflicts
         env:


### PR DESCRIPTION
## Summary
- Replace the lockfile conflict resolver's global `npm install -g pnpm@9` step with `pnpm/action-setup@v4`
- Keeps the resolver aligned with the repository `packageManager` / engines pin instead of floating across pnpm 9 releases

## Tests
- `corepack pnpm@9.6.0 --filter @opensourceframework/next-optimized-images test`
- `corepack pnpm@9.6.0 lint`
- `corepack pnpm@9.6.0 typecheck`
- `corepack pnpm@9.6.0 test`
- `git diff --check`
- workflow assertion: no remaining `npm install -g pnpm@9` in `.github/workflows/resolve-lockfile.yml`
