### PR TITLE
fix(compat): use workspace pnpm for smoke tests

### DIFF
--- a/packages/next-mdx-toc/package.json
+++ b/packages/next-mdx-toc/package.json
@@ -41,7 +41,7 @@
     "typescript": "^5.9.3"
   },
   "dependencies": {
-    "@opensourceframework/next-mdx": "workspace:*",
+    "@opensourceframework/next-mdx": "^0.6.2",
     "mdast-util-toc": "^5.1.0",
     "remark": "^13.0.0",
     "unist-util-visit": "^2.0.3"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -745,8 +745,8 @@ importers:
   packages/next-mdx-toc:
     dependencies:
       '@opensourceframework/next-mdx':
-        specifier: workspace:*
-        version: link:../next-mdx
+        specifier: ^0.6.2
+        version: 0.6.2(@types/react@19.2.14)(next@16.2.6(@babel/core@7.29.0)(@playwright/test@1.58.2)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react@19.2.4)
       mdast-util-toc:
         specifier: ^5.1.0
         version: 5.1.0
@@ -3317,6 +3317,13 @@ packages:
 
   '@open-draft/until@2.1.0':
     resolution: {integrity: sha512-U69T3ItWHvLwGg5eJ0n3I62nWuE6ilHlmz7zM0npLBRvPRd7e6NYmg54vvRtP5mZG7kZqZCFVdsTWo7BPtBujg==}
+
+  '@opensourceframework/next-mdx@0.6.2':
+    resolution: {integrity: sha512-chySlDAmw+FmqTrZsOmBOkENci0ApX3p5ONiR/IFeYwpMsl7s5drEiGCGBjmdXQEH2l3vqFwTStlM8V3GZ8Tvw==}
+    engines: {node: '>=18.0.0'}
+    peerDependencies:
+      next: '>=16.2.6'
+      react: '>= 16.8.0'
 
   '@panva/asn1.js@1.0.0':
     resolution: {integrity: sha512-UdkG3mLEqXgnlKsWanWcgb6dOjUzJ+XC5f+aWw30qrtjxeNUSfKX1cd5FBzOaXQumoe9nIqeZUvrRJS03HCCtw==}
@@ -14061,6 +14068,20 @@ snapshots:
       outvariant: 1.4.3
 
   '@open-draft/until@2.1.0': {}
+
+  '@opensourceframework/next-mdx@0.6.2(@types/react@19.2.14)(next@16.2.6(@babel/core@7.29.0)(@playwright/test@1.58.2)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react@19.2.4)':
+    dependencies:
+      '@mdx-js/react': 3.1.1(@types/react@19.2.14)(react@19.2.4)
+      crypto-hash: 4.0.1
+      fast-glob: 3.3.3
+      gray-matter: 4.0.3
+      next: 16.2.6(@babel/core@7.29.0)(@playwright/test@1.58.2)(babel-plugin-macros@3.1.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      next-mdx-remote: 6.0.0(@types/react@19.2.14)(react@19.2.4)
+      node-cache: 5.1.2
+      react: 19.2.4
+    transitivePeerDependencies:
+      - '@types/react'
+      - supports-color
 
   '@panva/asn1.js@1.0.0': {}
 

--- a/scripts/test-compat.mjs
+++ b/scripts/test-compat.mjs
@@ -4,9 +4,17 @@ import { copyFile, mkdtemp, mkdir, readFile, rm, unlink, writeFile } from 'node:
 import os from 'node:os';
 import path from 'node:path';
 import { spawn } from 'node:child_process';
+import { createRequire } from 'node:module';
 import { fileURLToPath } from 'node:url';
 
 const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+const require = createRequire(import.meta.url);
+const rootManifest = require('../package.json');
+const pnpmSpec = rootManifest.packageManager?.startsWith('pnpm@')
+  ? rootManifest.packageManager
+  : 'pnpm';
+const pnpmCommand = pnpmSpec === 'pnpm' ? 'pnpm' : 'corepack';
+const pnpmArgs = (args) => (pnpmCommand === 'corepack' ? [pnpmSpec, ...args] : args);
 const ciEnv = {
   ...process.env,
   CI: '1',
@@ -14,45 +22,43 @@ const ciEnv = {
 };
 
 function extractTopLevelJsonArray(text) {
-  let start = -1;
-  let depth = 0;
-  let inString = false;
-  let escaped = false;
+  for (let start = text.indexOf('['); start !== -1; start = text.indexOf('[', start + 1)) {
+    const nextNonWhitespace = text.slice(start + 1).match(/\S/);
+    if (nextNonWhitespace?.[0] !== '{') {
+      continue;
+    }
 
-  for (let index = 0; index < text.length; index += 1) {
-    const char = text[index];
+    let depth = 1;
+    let inString = false;
+    let escaped = false;
 
-    if (start === -1) {
+    for (let index = start + 1; index < text.length; index += 1) {
+      const char = text[index];
+
+      if (inString) {
+        if (escaped) {
+          escaped = false;
+        } else if (char === '\\') {
+          escaped = true;
+        } else if (char === '"') {
+          inString = false;
+        }
+        continue;
+      }
+
+      if (char === '"') {
+        inString = true;
+        continue;
+      }
+
       if (char === '[') {
-        start = index;
-        depth = 1;
-      }
-      continue;
-    }
+        depth += 1;
+      } else if (char === ']') {
+        depth -= 1;
 
-    if (inString) {
-      if (escaped) {
-        escaped = false;
-      } else if (char === '\\') {
-        escaped = true;
-      } else if (char === '"') {
-        inString = false;
-      }
-      continue;
-    }
-
-    if (char === '"') {
-      inString = true;
-      continue;
-    }
-
-    if (char === '[') {
-      depth += 1;
-    } else if (char === ']') {
-      depth -= 1;
-
-      if (depth === 0) {
-        return text.slice(start, index + 1);
+        if (depth === 0) {
+          return text.slice(start, index + 1);
+        }
       }
     }
   }
@@ -98,6 +104,10 @@ function run(command, args, options = {}) {
   });
 }
 
+function runPnpm(args, options = {}) {
+  return run(pnpmCommand, pnpmArgs(args), options);
+}
+
 async function writeFiles(rootDir, files) {
   for (const [relativePath, contents] of Object.entries(files)) {
     const filePath = path.join(rootDir, relativePath);
@@ -107,7 +117,7 @@ async function writeFiles(rootDir, files) {
 }
 
 async function buildPackage(filter) {
-  await run('pnpm', ['--filter', filter, 'build'], {
+  await runPnpm(['--filter', filter, 'build'], {
     cwd: repoRoot,
     env: ciEnv,
   });
@@ -150,10 +160,19 @@ async function packPackage(relativeDir, tarballDir) {
 }
 
 async function installAndRun(packageDir, command, args = []) {
-  await run('pnpm', ['install', '--reporter', 'append-only'], {
+  await runPnpm(['install', '--reporter', 'append-only'], {
     cwd: packageDir,
     env: ciEnv,
   });
+
+  if (command === 'pnpm') {
+    await runPnpm(args, {
+      cwd: packageDir,
+      env: ciEnv,
+    });
+    return;
+  }
+
   await run(command, args, {
     cwd: packageDir,
     env: ciEnv,


### PR DESCRIPTION
## Summary
- Runs compatibility smoke-test pnpm commands through the root packageManager via corepack so local pnpm 9.0.0 does not trip the repo's >=9.6.0 engine requirement.
- Makes npm pack JSON parsing resilient to package build logs before the JSON array.
- Replaces the publish-blocking workspace runtime dependency in @opensourceframework/next-mdx-toc with the currently published @opensourceframework/next-mdx range.

## Tests
- corepack pnpm@9.6.0 install --frozen-lockfile --lockfile-only
- corepack pnpm@9.6.0 exec eslint scripts/test-compat.mjs
- corepack pnpm@9.6.0 --filter @opensourceframework/next-mdx-toc test
- corepack pnpm@9.6.0 --filter @opensourceframework/next-mdx-toc build
- TMPDIR=/home/dario/.hermes/tmp/osf-compat-tmp corepack pnpm@9.6.0 test:compat

Note: plain test:compat hit local /tmp inode exhaustion; reran with TMPDIR on /home successfully.