### PR TITLE
chore: ignore node_modules symlinks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 # Dependencies
+node_modules
 node_modules/
 .pnpm-store/
 


### PR DESCRIPTION
## Summary
- Ensures a root-level `node_modules` symlink is ignored, not just real directories matching `node_modules/`.
- Prevents shared-dependency worktree setups from showing `node_modules` as an accidentally stageable untracked symlink.

## Tests
- `git status --short --ignored` before/after the change to verify the symlink moves from untracked to ignored
- `git diff --check`
- `corepack pnpm@9.6.0 --filter @opensourceframework/next-optimized-images test`
- `corepack pnpm@9.6.0 test`
- `corepack pnpm@9.6.0 lint`