### PR TITLE
chore(root): update Husky prepare script

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "showcase"
   ],
   "scripts": {
-    "prepare": "husky install",
+    "prepare": "husky",
     "test": "turbo run test",
     "test:compat": "node scripts/test-compat.mjs",
     "test:coverage": "turbo run test:coverage",


### PR DESCRIPTION
## Summary
- Replace the deprecated `husky install` prepare command with the Husky v9 `husky` command.
- Keeps install output clean while preserving hook setup.

## Tests run
- `corepack pnpm@9.6.0 run prepare`
- `corepack pnpm@9.6.0 install --frozen-lockfile`
- `corepack pnpm@9.6.0 lint`
- `corepack pnpm@9.6.0 test`
- `git diff --check`
- staged changed-line secret scan