### PR TITLE
test(react-virtualized): enable collection scroll cache coverage

### DIFF
--- a/packages/react-virtualized/source-stripped/Collection/Collection.jest.jsx
+++ b/packages/react-virtualized/source-stripped/Collection/Collection.jest.jsx
@@ -758,7 +758,7 @@ describe('Collection', () => {
       );
     });
 
-    it.skip('should cache a cell once it has been rendered while scrolling', () => {
+    it('should cache a cell once it has been rendered while scrolling', () => {
       const cellRendererCalls = [];
       function cellRenderer({isScrolling, index, key, style}) {
         cellRendererCalls.push({isScrolling, index});
@@ -767,8 +767,6 @@ describe('Collection', () => {
 
       const props = {
         cellRenderer,
-        scrollLeft: 0,
-        scrollTop: 0,
       };
 
       const collection = render(getMarkup(props));
@@ -777,7 +775,6 @@ describe('Collection', () => {
         expect(call.isScrolling).toEqual(false),
       );
 
-      // FIXME: simulate scroll is not triggering cells to render in cache
       // Scroll a little bit; newly-rendered cells will be cached.
       simulateScroll({collection, scrollTop: 2});
 

--- a/packages/react-virtualized/source/Collection/Collection.jest.js
+++ b/packages/react-virtualized/source/Collection/Collection.jest.js
@@ -758,7 +758,7 @@ describe('Collection', () => {
       );
     });
 
-    it.skip('should cache a cell once it has been rendered while scrolling', () => {
+    it('should cache a cell once it has been rendered while scrolling', () => {
       const cellRendererCalls = [];
       function cellRenderer({isScrolling, index, key, style}) {
         cellRendererCalls.push({isScrolling, index});
@@ -767,8 +767,6 @@ describe('Collection', () => {
 
       const props = {
         cellRenderer,
-        scrollLeft: 0,
-        scrollTop: 0,
       };
 
       const collection = render(getMarkup(props));
@@ -777,7 +775,6 @@ describe('Collection', () => {
         expect(call.isScrolling).toEqual(false),
       );
 
-      // FIXME: simulate scroll is not triggering cells to render in cache
       // Scroll a little bit; newly-rendered cells will be cached.
       simulateScroll({collection, scrollTop: 2});
 


### PR DESCRIPTION
## Summary
- Enables the previously skipped `Collection` scroll-cache regression test in `react-virtualized`.
- Fixes the test setup by making the initial render uncontrolled; the old explicit `scrollTop: 0`/`scrollLeft: 0` props caused `getDerivedStateFromProps` to reset simulated scrolling back to the initial offset, so the cache assertion never exercised the intended scrolled viewport.
- Applies the same test update to both `source` and `source-stripped` copies.

## Tests
- `corepack pnpm@9.6.0 --filter @opensourceframework/react-virtualized test -- source-stripped/Collection/Collection.jest.jsx`
- `corepack pnpm@9.6.0 --filter @opensourceframework/react-virtualized test`
- `corepack pnpm@9.6.0 --filter @opensourceframework/react-virtualized lint`
- `corepack pnpm@9.6.0 --filter @opensourceframework/react-virtualized typecheck`
- `git diff --check`
- staged secret scan
