### PR TITLE
docs(next-images): mark package as maintained

### DIFF
--- a/plans/issue-resolution-status.md
+++ b/plans/issue-resolution-status.md
@@ -159,14 +159,14 @@ All 29 tests (including security and functionality) are passing.
 
 ## next-images (Original Package)
 
-### Status: ⚠️ DEPRECATED (Tests Pass)
+### Status: ✅ READY
 
 | Metric | Value |
 |--------|-------|
 | Tests | 40 passed, 0 failed |
 | Security | No known vulnerabilities |
 | TypeScript | Full type definitions |
-| Deprecation | Marked as deprecated in package.json |
+| Compatibility strategy | Maintained drop-in fork; do not steer users to `next/image` by default |
 
 ---
 
@@ -214,7 +214,7 @@ All 29 tests (including security and functionality) are passing.
 | next-compose-plugins | ✅ 29 passed | ✅ Secure | ✅ Updated | ✅ **YES** |
 | next-transpile-modules | ✅ 57 passed | ✅ Secure | ✅ Good | ✅ **YES** |
 | next-mdx | ✅ 8 passed | ✅ Secure | ✅ Good | ✅ **YES** |
-| next-images | ✅ 40 passed | ✅ Secure | ✅ Good | ⚠️ **DEPRECATED** |
+| next-images | ✅ 40 passed | ✅ Secure | ✅ Good | ✅ **YES** |
 | next-cookies | ✅ 12 passed | ✅ Secure | ✅ Updated | ✅ **YES** |
 | next-pwa | ✅ 8 passed | ✅ Secure | ✅ Good | ✅ **YES** |
 


### PR DESCRIPTION
## Summary
- Updates the issue-resolution status doc so next-images is marked as a maintained compatibility package, not deprecated.
- Aligns the package readiness matrix with the current README/package metadata and repo compatibility-first policy.

## Tests
- corepack pnpm@9.6.0 --filter @opensourceframework/next-images test
- corepack pnpm@9.6.0 exec prettier --check plans/issue-resolution-status.md
- git diff --check
- corepack pnpm@9.6.0 test
- corepack pnpm@9.6.0 lint
- corepack pnpm@9.6.0 audit --audit-level moderate --json