### PR TITLE
docs: align pnpm prerequisite docs

### DIFF
--- a/packages/critters/CONTRIBUTING.md
+++ b/packages/critters/CONTRIBUTING.md
@@ -22,7 +22,7 @@ This project follows the [Contributor Covenant Code of Conduct](./CODE_OF_CONDUC
 ### Prerequisites
 
 - **Node.js**: Version 20.0.0 or higher
-- **pnpm**: Version 9.0.0 or higher
+- **pnpm**: Version 9.6.0 or higher
 - **Git**: For version control
 
 ### Initial Setup

--- a/packages/critters/plans/architecture.md
+++ b/packages/critters/plans/architecture.md
@@ -163,9 +163,9 @@ coverage/
   "type": "module",
   "engines": {
     "node": ">=20.0.0",
-    "pnpm": ">=9.0.0"
+    "pnpm": ">=9.6.0"
   },
-  "packageManager": "pnpm@9.15.0",
+  "packageManager": "pnpm@9.6.0",
   "scripts": {
     "build": "turbo run build",
     "dev": "turbo run dev",

--- a/packages/next-circuit-breaker/CONTRIBUTING.md
+++ b/packages/next-circuit-breaker/CONTRIBUTING.md
@@ -22,7 +22,7 @@ This project follows the [Contributor Covenant Code of Conduct](./CODE_OF_CONDUC
 ### Prerequisites
 
 - **Node.js**: Version 20.0.0 or higher
-- **pnpm**: Version 9.0.0 or higher
+- **pnpm**: Version 9.6.0 or higher
 - **Git**: For version control
 
 ### Initial Setup

--- a/packages/next-circuit-breaker/plans/architecture.md
+++ b/packages/next-circuit-breaker/plans/architecture.md
@@ -163,9 +163,9 @@ coverage/
   "type": "module",
   "engines": {
     "node": ">=20.0.0",
-    "pnpm": ">=9.0.0"
+    "pnpm": ">=9.6.0"
   },
-  "packageManager": "pnpm@9.15.0",
+  "packageManager": "pnpm@9.6.0",
   "scripts": {
     "build": "turbo run build",
     "dev": "turbo run dev",

--- a/packages/next-csrf/CONTRIBUTING.md
+++ b/packages/next-csrf/CONTRIBUTING.md
@@ -22,7 +22,7 @@ This project follows the [Contributor Covenant Code of Conduct](./CODE_OF_CONDUC
 ### Prerequisites
 
 - **Node.js**: Version 20.0.0 or higher
-- **pnpm**: Version 9.0.0 or higher
+- **pnpm**: Version 9.6.0 or higher
 - **Git**: For version control
 
 ### Initial Setup

--- a/packages/next-csrf/plans/architecture.md
+++ b/packages/next-csrf/plans/architecture.md
@@ -163,9 +163,9 @@ coverage/
   "type": "module",
   "engines": {
     "node": ">=20.0.0",
-    "pnpm": ">=9.0.0"
+    "pnpm": ">=9.6.0"
   },
-  "packageManager": "pnpm@9.15.0",
+  "packageManager": "pnpm@9.6.0",
   "scripts": {
     "build": "turbo run build",
     "dev": "turbo run dev",

--- a/packages/next-images/CONTRIBUTING.md
+++ b/packages/next-images/CONTRIBUTING.md
@@ -22,7 +22,7 @@ This project follows the [Contributor Covenant Code of Conduct](./CODE_OF_CONDUC
 ### Prerequisites
 
 - **Node.js**: Version 20.0.0 or higher
-- **pnpm**: Version 9.0.0 or higher
+- **pnpm**: Version 9.6.0 or higher
 - **Git**: For version control
 
 ### Initial Setup

--- a/packages/next-images/plans/architecture.md
+++ b/packages/next-images/plans/architecture.md
@@ -163,9 +163,9 @@ coverage/
   "type": "module",
   "engines": {
     "node": ">=20.0.0",
-    "pnpm": ">=9.0.0"
+    "pnpm": ">=9.6.0"
   },
-  "packageManager": "pnpm@9.15.0",
+  "packageManager": "pnpm@9.6.0",
   "scripts": {
     "build": "turbo run build",
     "dev": "turbo run dev",

--- a/packages/next-json-ld/CONTRIBUTING.md
+++ b/packages/next-json-ld/CONTRIBUTING.md
@@ -22,7 +22,7 @@ This project follows the [Contributor Covenant Code of Conduct](./CODE_OF_CONDUC
 ### Prerequisites
 
 - **Node.js**: Version 20.0.0 or higher
-- **pnpm**: Version 9.0.0 or higher
+- **pnpm**: Version 9.6.0 or higher
 - **Git**: For version control
 
 ### Initial Setup

--- a/packages/next-json-ld/plans/architecture.md
+++ b/packages/next-json-ld/plans/architecture.md
@@ -163,9 +163,9 @@ coverage/
   "type": "module",
   "engines": {
     "node": ">=20.0.0",
-    "pnpm": ">=9.0.0"
+    "pnpm": ">=9.6.0"
   },
-  "packageManager": "pnpm@9.15.0",
+  "packageManager": "pnpm@9.6.0",
   "scripts": {
     "build": "turbo run build",
     "dev": "turbo run dev",

--- a/packages/react-a11y-utils/CONTRIBUTING.md
+++ b/packages/react-a11y-utils/CONTRIBUTING.md
@@ -22,7 +22,7 @@ This project follows the [Contributor Covenant Code of Conduct](./CODE_OF_CONDUC
 ### Prerequisites
 
 - **Node.js**: Version 20.0.0 or higher
-- **pnpm**: Version 9.0.0 or higher
+- **pnpm**: Version 9.6.0 or higher
 - **Git**: For version control
 
 ### Initial Setup

--- a/packages/react-a11y-utils/plans/architecture.md
+++ b/packages/react-a11y-utils/plans/architecture.md
@@ -163,9 +163,9 @@ coverage/
   "type": "module",
   "engines": {
     "node": ">=20.0.0",
-    "pnpm": ">=9.0.0"
+    "pnpm": ">=9.6.0"
   },
-  "packageManager": "pnpm@9.15.0",
+  "packageManager": "pnpm@9.6.0",
   "scripts": {
     "build": "turbo run build",
     "dev": "turbo run dev",

--- a/packages/seeded-rng/CONTRIBUTING.md
+++ b/packages/seeded-rng/CONTRIBUTING.md
@@ -22,7 +22,7 @@ This project follows the [Contributor Covenant Code of Conduct](./CODE_OF_CONDUC
 ### Prerequisites
 
 - **Node.js**: Version 20.0.0 or higher
-- **pnpm**: Version 9.0.0 or higher
+- **pnpm**: Version 9.6.0 or higher
 - **Git**: For version control
 
 ### Initial Setup

--- a/packages/seeded-rng/plans/architecture.md
+++ b/packages/seeded-rng/plans/architecture.md
@@ -163,9 +163,9 @@ coverage/
   "type": "module",
   "engines": {
     "node": ">=20.0.0",
-    "pnpm": ">=9.0.0"
+    "pnpm": ">=9.6.0"
   },
-  "packageManager": "pnpm@9.15.0",
+  "packageManager": "pnpm@9.6.0",
   "scripts": {
     "build": "turbo run build",
     "dev": "turbo run dev",

--- a/plans/architecture.md
+++ b/plans/architecture.md
@@ -163,9 +163,9 @@ coverage/
   "type": "module",
   "engines": {
     "node": ">=20.0.0",
-    "pnpm": ">=9.0.0"
+    "pnpm": ">=9.6.0"
   },
-  "packageManager": "pnpm@9.15.0",
+  "packageManager": "pnpm@9.6.0",
   "scripts": {
     "build": "turbo run build",
     "dev": "turbo run dev",


### PR DESCRIPTION
## Summary
- Updates package CONTRIBUTING prerequisites to require pnpm 9.6.0, matching the root packageManager/engines contract.
- Aligns duplicated architecture plan snippets so generated setup guidance does not suggest stale pnpm 9.0/9.15 values.

## Tests run
- git diff --check
- corepack pnpm@9.6.0 exec prettier --check <changed markdown files>
- corepack pnpm@9.6.0 --filter @opensourceframework/next-optimized-images test
- corepack pnpm@9.6.0 test
- corepack pnpm@9.6.0 lint
- corepack pnpm@9.6.0 typecheck

Note: full 
> @opensourceframework/monorepo@1.0.0 format:check /tmp/osf-maint-20260529-213932
> prettier --check "**/*.{ts,tsx,js,jsx,json,md,yml,yaml}"

Checking formatting...
 ELIFECYCLE  Command failed with exit code 1. still fails on pre-existing repo-wide formatting drift outside this PR; changed files pass Prettier.