### PR TITLE
docs(next-transpile-modules): clarify maintenance status

### DIFF
--- a/.changeset/friendly-otters-transpile.md
+++ b/.changeset/friendly-otters-transpile.md
@@ -1,0 +1,5 @@
+---
+"@opensourceframework/next-transpile-modules": patch
+---
+
+Clarify that the OpenSourceFramework fork remains maintained as a compatibility package rather than deprecated upstream life-support guidance.

--- a/packages/next-transpile-modules/README.md
+++ b/packages/next-transpile-modules/README.md
@@ -1,13 +1,12 @@
-> **Note**
-> All `@opensourceframework/next-transpile-modules` features have natively landed to Next.js 13.1, you can check [the migration guide here](https://github.com/martpie/@opensourceframework/next-transpile-modules/releases/tag/the-end).
->
-> This package is now officially deprecated and on life-support.
->
-> PRs with fixes are welcome and I will help review them, but that's it. I **highly** recommend contributing to Next.js in case your setup is not working there.
-
----
-
 # Next.js + Transpile `node_modules`
+
+> **Maintenance note**
+> `@opensourceframework/next-transpile-modules` is maintained as a compatibility-first
+> fork for projects that still depend on the plugin API. Next.js 13.1+ includes native
+> `transpilePackages` support for many setups, but this package is not deprecated in the
+> OpenSourceFramework fork. Native Next.js support is a good option for new applications;
+> this package remains available for existing integrations and edge cases that need the
+> original plugin behavior.
 
 ![Build Status](https://github.com/martpie/@opensourceframework/next-transpile-modules/workflows/tests/badge.svg)
 


### PR DESCRIPTION
## Summary
- replaces stale upstream deprecation/life-support README guidance with OpenSourceFramework compatibility-first maintenance language
- keeps native Next.js transpilePackages as an option without marking the fork deprecated
- adds a patch changeset for the package README update

## Tests
- corepack pnpm@9.6.0 --filter @opensourceframework/next-transpile-modules test
- corepack pnpm@9.6.0 --filter @opensourceframework/next-transpile-modules test:lint
- git diff --check
- staged changed-line secret scan