### PR TITLE
docs: pin contributor pnpm commands to 9.6.0

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,15 +4,17 @@
 This repository is a pnpm/Turbo monorepo for published `@opensourceframework/*` packages. Put package code in `packages/<name>/src`, package tests in `test/`, `src/**/*.test.*`, or `src/__tests__/`, and keep demos in `examples/`, `test-app/`, or `www/` when a package already uses them. Shared workspace tooling lives in `tools/` (`eslint-config`, `prettier-config`, `tsconfig`). Repo automation is in `scripts/`, starter files are in `templates/`, and maintenance/security notes live in `plans/`.
 
 ## Build, Test, and Development Commands
-Use Node 20 and `pnpm@9` locally to match the main CI path.
+Use Node 20 and `pnpm@9.6.0` locally to match the main CI path and the root
+`packageManager`/`engines` constraints. If your global pnpm is older, run commands through
+Corepack, for example `corepack pnpm@9.6.0 test`.
 
-- `pnpm install` installs all workspaces.
-- `pnpm build` runs Turbo builds across packages.
-- `pnpm test` runs each package’s own test script.
-- `pnpm test:coverage` runs the CI-style coverage pass.
-- `pnpm lint` and `pnpm typecheck` run repo-wide quality checks.
-- `pnpm --filter @opensourceframework/next-cookies test` targets one published package.
-- `pnpm --filter @opensourceframework/next-connect dev` starts a package watch/dev script when available.
+- `corepack pnpm@9.6.0 install` installs all workspaces.
+- `corepack pnpm@9.6.0 build` runs Turbo builds across packages.
+- `corepack pnpm@9.6.0 test` runs each package’s own test script.
+- `corepack pnpm@9.6.0 test:coverage` runs the CI-style coverage pass.
+- `corepack pnpm@9.6.0 lint` and `corepack pnpm@9.6.0 typecheck` run repo-wide quality checks.
+- `corepack pnpm@9.6.0 --filter @opensourceframework/next-cookies test` targets one published package.
+- `corepack pnpm@9.6.0 --filter @opensourceframework/next-connect dev` starts a package watch/dev script when available.
 
 ## Coding Style & Naming Conventions
 Prettier is the source of truth: 2-space indentation, single quotes, semicolons, trailing commas (`es5`), and 100-character lines. Root linting is ESLint via `eslint.config.mjs`; most packages follow that directly, while a few keep package-local tooling. Preserve package-local config files such as `tsup.config.ts`, `vitest.config.ts`, and `tsconfig.json`. Use kebab-case package directories, keep public entrypoints in `src/index.ts`, and name tests `*.test.ts` or `*.test.tsx`.


### PR DESCRIPTION
## Summary
- Updates AGENTS.md to match the root pnpm@9.6.0 packageManager/engine constraints.
- Documents Corepack usage so repo checks don't fail under older pnpm 9.x releases.

## Tests
- corepack pnpm@9.6.0 exec prettier --check AGENTS.md
- corepack pnpm@9.6.0 --filter @opensourceframework/next-iron-session test
- git diff --check