### PR TITLE
docs(next-seo): align contributor commands with monorepo

### DIFF
--- a/packages/next-seo/AGENTS.md
+++ b/packages/next-seo/AGENTS.md
@@ -17,49 +17,49 @@ You must check these after coming up with a plan
 ### Installation
 
 ```bash
-pnpm install
+corepack pnpm@9.6.0 install
 ```
 
 ### Build & Development
 
 ```bash
-pnpm dev          # Watch mode with tsup
-pnpm build        # Build library code
+corepack pnpm@9.6.0 --filter @opensourceframework/next-seo dev    # Watch mode with tsup
+corepack pnpm@9.6.0 --filter @opensourceframework/next-seo build  # Build library code
 ```
 
 ### Code Quality
 
 ```bash
-pnpm lint         # Run ESLint
-pnpm lint:fix     # Fix ESLint issues
-pnpm format       # Format with Prettier
-pnpm typecheck    # Type checking with TypeScript
+corepack pnpm@9.6.0 --filter @opensourceframework/next-seo lint       # Run ESLint
+corepack pnpm@9.6.0 --filter @opensourceframework/next-seo lint:fix   # Fix ESLint issues
+corepack pnpm@9.6.0 format                                             # Format with Prettier
+corepack pnpm@9.6.0 --filter @opensourceframework/next-seo typecheck  # Type checking with TypeScript
 ```
 
 ### Testing
 
 ```bash
-pnpm test         # Run typecheck + lint only
-pnpm test:unit    # Run unit tests with Vitest
-pnpm test:unit:watch  # Watch mode for unit tests
-pnpm coverage     # Generate coverage report
+corepack pnpm@9.6.0 --filter @opensourceframework/next-seo test             # Run typecheck + lint only
+corepack pnpm@9.6.0 --filter @opensourceframework/next-seo test:unit        # Run unit tests with Vitest
+corepack pnpm@9.6.0 --filter @opensourceframework/next-seo test:unit:watch  # Watch mode for unit tests
+corepack pnpm@9.6.0 --filter @opensourceframework/next-seo coverage         # Generate coverage report
 # Requires pnpm build to run first
-pnpm test:e2e     # Run E2E tests with Playwright
-pnpm test:e2e:ui  # Run E2E tests with UI
+corepack pnpm@9.6.0 --filter @opensourceframework/next-seo test:e2e     # Run E2E tests with Playwright
+corepack pnpm@9.6.0 --filter @opensourceframework/next-seo test:e2e:ui  # Run E2E tests with UI
 ```
 
 ### Example App
 
 ```bash
-pnpm example:dev    # Run example app at localhost:3001
-pnpm example:build  # Build example app
-pnpm example:start  # Start example app
+corepack pnpm@9.6.0 --filter @opensourceframework/next-seo example:dev    # Run example app at localhost:3001
+corepack pnpm@9.6.0 --filter @opensourceframework/next-seo example:build  # Build example app
+corepack pnpm@9.6.0 --filter @opensourceframework/next-seo example:start  # Start example app
 ```
 
 ### Utilities
 
 ```bash
-pnpm clean        # Clean build artifacts
+corepack pnpm@9.6.0 --filter @opensourceframework/next-seo clean  # Clean build artifacts
 ```
 
 ## Project Architecture

--- a/packages/next-seo/CONTRIBUTING.md
+++ b/packages/next-seo/CONTRIBUTING.md
@@ -6,12 +6,12 @@ It is critical that you look over the guidance for new components [here](ADDING_
 
 ## 🚀 Quick Start
 
-1. Fork the repository
-2. Clone your fork: `git clone git@github.com:your-username/next-seo.git`
-3. Install dependencies: `pnpm install`
+1. Fork the OpenSourceFramework monorepo
+2. Clone your fork: `git clone git@github.com:your-username/opensourceframework.git`
+3. Install dependencies: `corepack pnpm@9.6.0 install`
 4. Create a new branch: `git checkout -b feature/your-feature-name`
-5. Make your changes
-6. Add a changeset: `pnpm changeset`
+5. Make your changes in `packages/next-seo`
+6. Add a changeset when your change affects the published package: `corepack pnpm@9.6.0 changeset`
 7. Submit a pull request
 
 ## 📦 Development Setup
@@ -19,33 +19,33 @@ It is critical that you look over the guidance for new components [here](ADDING_
 ### Prerequisites
 
 - Node.js 20+ (LTS recommended)
-- pnpm 9+ (`npm install -g pnpm`)
+- pnpm 9.6.0 via Corepack
 
 ### Installation
 
 ```bash
-# Clone the repository
-git clone git@github.com:garmeeh/next-seo.git
-cd next-seo
+# Clone the OpenSourceFramework monorepo
+git clone git@github.com:riceharvest/opensourceframework.git
+cd opensourceframework
 
 # Install dependencies
-pnpm install
+corepack pnpm@9.6.0 install
 
-# Start development (watch mode)
-pnpm dev
+# Start next-seo development (watch mode)
+corepack pnpm@9.6.0 --filter @opensourceframework/next-seo dev
 ```
 
 ### Available Commands
 
 ```bash
-pnpm dev          # Watch mode development
-pnpm build        # Build the library
-pnpm test         # Run type checking and linting
-pnpm test:unit    # Run unit tests
-pnpm test:e2e     # Run E2E tests (requires build first)
-pnpm test:sweep   # Run full test suite (CI equivalent)
-pnpm lint         # Check linting
-pnpm format       # Format code with Prettier
+corepack pnpm@9.6.0 --filter @opensourceframework/next-seo dev        # Watch mode development
+corepack pnpm@9.6.0 --filter @opensourceframework/next-seo build      # Build the library
+corepack pnpm@9.6.0 --filter @opensourceframework/next-seo test       # Run type checking and linting
+corepack pnpm@9.6.0 --filter @opensourceframework/next-seo test:unit  # Run unit tests
+corepack pnpm@9.6.0 --filter @opensourceframework/next-seo test:e2e   # Run E2E tests (requires build first)
+corepack pnpm@9.6.0 --filter @opensourceframework/next-seo test:sweep # Run full test suite (CI equivalent)
+corepack pnpm@9.6.0 --filter @opensourceframework/next-seo lint       # Check linting
+corepack pnpm@9.6.0 format                                             # Format code with Prettier
 ```
 
 ## 📝 Adding a Changeset
@@ -62,7 +62,7 @@ A changeset is a piece of information about changes made in a branch or commit. 
 
 ### How to add a changeset:
 
-1. After making your changes, run: `pnpm changeset`
+1. After making package changes, run: `corepack pnpm@9.6.0 changeset`
 2. Select the packages affected (usually just `next-seo`)
 3. Choose the type of change:
    - **patch**: Bug fixes, documentation, internal changes (0.0.X) **Rarely use this, generally only for security, since this is an SEO package I don't want patches to slip through for people without validating**
@@ -74,7 +74,7 @@ A changeset is a piece of information about changes made in a branch or commit. 
 ### Example:
 
 ```bash
-$ pnpm changeset
+$ corepack pnpm@9.6.0 changeset
 🦋 Which packages would you like to include? › next-seo
 🦋 Which packages should have a major bump? › (none)
 🦋 Which packages should have a minor bump? › next-seo
@@ -121,11 +121,11 @@ Before submitting a PR, ensure all tests pass:
 
 ```bash
 # Quick checks
-pnpm test         # Type checking and linting
-pnpm test:unit    # Unit tests
+corepack pnpm@9.6.0 --filter @opensourceframework/next-seo test       # Type checking and linting
+corepack pnpm@9.6.0 --filter @opensourceframework/next-seo test:unit  # Unit tests
 
 # Full validation (what CI runs)
-pnpm test:sweep   # Complete test suite
+corepack pnpm@9.6.0 --filter @opensourceframework/next-seo test:sweep # Complete test suite
 ```
 
 ## 🔄 Pull Request Process
@@ -147,7 +147,7 @@ pnpm test:sweep   # Complete test suite
 
 ## ❓ Questions?
 
-- Open a [Discussion](https://github.com/garmeeh/next-seo/discussions) for general questions
+- Open a [Discussion](https://github.com/riceharvest/opensourceframework/discussions) for general questions
 - Check existing issues and PRs
 - Refer to the [README](./README.md) for usage documentation
 


### PR DESCRIPTION
## Summary
- Updates next-seo contributor setup docs to clone the OpenSourceFramework monorepo instead of the upstream standalone repo
- Pins contributor commands to Corepack pnpm 9.6.0 and scopes package commands with `--filter @opensourceframework/next-seo`
- Updates stale discussion links to this repository

## Tests
- `corepack pnpm@9.6.0 exec prettier --check packages/next-seo/CONTRIBUTING.md packages/next-seo/AGENTS.md`
- `corepack pnpm@9.6.0 --filter @opensourceframework/next-seo lint`
- `corepack pnpm@9.6.0 --filter @opensourceframework/next-seo test`
- `git diff --check`
- staged secret scan