### PR TITLE
docs: align Next 16 compatibility matrix

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ We rigorously test our packages against a matrix of framework versions to ensure
 
 | Framework Versions | Status | Verified Packages |
 |--------------------|--------|-------------------|
-| **Next.js 16.1.6** / **React 19.2.0** | ✅ SAFE | next-images, next-compose-plugins, next-mdx, next-session, next-auth, react-virtualized, and more |
+| **Next.js 16.2.6** / **React 19.2.0** | ✅ SAFE | next-images, next-compose-plugins, next-mdx, next-session, next-auth, react-virtualized, and more |
 | **Next.js 15.2.0** / **React 19.0.0** | ✅ SAFE | next-images, next-compose-plugins, next-mdx, next-session, next-auth, react-virtualized, and more |
 | **Next.js 14.2.24** / **React 18.3.1** | ✅ SAFE | next-images, next-compose-plugins, next-mdx, next-session, next-auth, react-virtualized, and more |
 

--- a/plans/issue-resolution-status.md
+++ b/plans/issue-resolution-status.md
@@ -8,7 +8,7 @@
 |--------------------|--------|-------------------|
 | Next.js 14.2.24 / React 18.3.1 | ✅ SAFE | next-images, next-compose-plugins, next-optimized-images, next-mdx, next-session, next-auth, react-virtualized |
 | Next.js 15.2.0 / React 19.0.0 | ✅ SAFE | next-images, next-compose-plugins, next-optimized-images, next-mdx, next-session, next-auth, react-virtualized |
-| Next.js 16.1.6 / React 19.2.0 | ✅ SAFE | next-images, next-compose-plugins, next-optimized-images, next-mdx, next-session, next-auth, react-virtualized |
+| Next.js 16.2.6 / React 19.2.0 | ✅ SAFE | next-images, next-compose-plugins, next-optimized-images, next-mdx, next-session, next-auth, react-virtualized |
 
 ---
 


### PR DESCRIPTION
## Summary
- Updates the README compatibility matrix from Next.js 16.1.6 to the current verified Next.js 16.2.6 line.
- Keeps the package issue-resolution status matrix aligned with the repo's pinned Next.js test/dependency version.

## Tests
- corepack pnpm@9.6.0 install --frozen-lockfile
- corepack pnpm@9.6.0 lint
- corepack pnpm@9.6.0 test
- corepack pnpm@9.6.0 typecheck
- corepack pnpm@9.6.0 exec prettier --check README.md plans/issue-resolution-status.md
- corepack pnpm@9.6.0 audit --audit-level=moderate
- git diff --check