### PR TITLE
docs: pin contributor pnpm commands

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -126,24 +126,24 @@ chore(deps): update typescript to v5.4.0
 3. **Test your changes**
    ```bash
    # Run tests for all packages
-   pnpm test
+   corepack pnpm@9.6.0 test
    
    # Run tests for a specific package
-   pnpm --filter @opensourceframework/next-csrf test
+   corepack pnpm@9.6.0 --filter @opensourceframework/next-csrf test
    
    # Run tests with coverage
-   pnpm test:coverage
+   corepack pnpm@9.6.0 test:coverage
    ```
 
 4. **Lint and format**
    ```bash
-   pnpm lint
-   pnpm format
+   corepack pnpm@9.6.0 lint
+   corepack pnpm@9.6.0 format
    ```
 
 5. **Create a changeset** (for user-facing changes)
    ```bash
-   pnpm changeset
+   corepack pnpm@9.6.0 changeset
    ```
    This will prompt you to:
    - Select affected packages
@@ -175,8 +175,8 @@ chore(deps): update typescript to v5.4.0
 
 - Formatting is enforced via Prettier
 - Linting rules are enforced via ESLint
-- Run `pnpm format` before committing
-- Run `pnpm lint` to check for issues
+- Run `corepack pnpm@9.6.0 format` before committing
+- Run `corepack pnpm@9.6.0 lint` to check for issues
 
 ### File Organization
 
@@ -206,16 +206,16 @@ packages/[package-name]/
 
 ```bash
 # All tests
-pnpm test
+corepack pnpm@9.6.0 test
 
 # Watch mode
-pnpm --filter @opensourceframework/next-csrf test:watch
+corepack pnpm@9.6.0 --filter @opensourceframework/next-csrf test:watch
 
 # Coverage report
-pnpm test:coverage
+corepack pnpm@9.6.0 test:coverage
 
 # Specific test file
-pnpm --filter @opensourceframework/next-csrf vitest run src/index.test.ts
+corepack pnpm@9.6.0 --filter @opensourceframework/next-csrf vitest run src/index.test.ts
 ```
 
 ### Writing Tests

--- a/packages/CONTRIBUTING.md
+++ b/packages/CONTRIBUTING.md
@@ -21,8 +21,8 @@ Welcome! This document provides guidelines for contributing to any `@opensourcef
 2. **Pick a package** to work on from `packages/`
 3. **Create a branch**: `git checkout -b feat/package-name/feature`
 4. **Make changes** following the guidelines below
-5. **Test thoroughly**: `pnpm --filter @opensourceframework/package-name test`
-6. **Create a changeset**: `pnpm changeset`
+5. **Test thoroughly**: `corepack pnpm@9.6.0 --filter @opensourceframework/package-name test`
+6. **Create a changeset**: `corepack pnpm@9.6.0 changeset`
 7. **Open a PR** with completed checklist
 
 ## Package Status
@@ -112,19 +112,19 @@ All packages must meet these testing standards:
 
 ```bash
 # All packages
-pnpm test
+corepack pnpm@9.6.0 test
 
 # Specific package
-pnpm --filter @opensourceframework/next-csrf test
+corepack pnpm@9.6.0 --filter @opensourceframework/next-csrf test
 
 # With coverage
-pnpm --filter @opensourceframework/package-name test:coverage
+corepack pnpm@9.6.0 --filter @opensourceframework/package-name test:coverage
 
 # Watch mode
-pnpm --filter @opensourceframework/package-name test:watch
+corepack pnpm@9.6.0 --filter @opensourceframework/package-name test:watch
 
 # Type checking
-pnpm --filter @opensourceframework/package-name typecheck
+corepack pnpm@9.6.0 --filter @opensourceframework/package-name typecheck
 ```
 
 ### Test File Location
@@ -176,7 +176,7 @@ List features that are deprecated and alternatives.
 
 ### Upgrade Steps
 
-1. Update package: `pnpm update @opensourceframework/package-name`
+1. Update package: `corepack pnpm@9.6.0 update @opensourceframework/package-name`
 2. Update code according to changes
 3. Run tests
 4. Test your application thoroughly
@@ -206,7 +206,7 @@ Releases are managed via [Changesets](https://github.com/changesets/changesets).
 
 1. **Create a changeset** after merging your PR:
    ```bash
-   pnpm changeset
+   corepack pnpm@9.6.0 changeset
    ```
    - Select affected packages
    - Choose version bump (major/minor/patch)
@@ -229,11 +229,11 @@ Releases are managed via [Changesets](https://github.com/changesets/changesets).
 
 ### For Maintainers
 
-1. **Version bump**: `pnpm changeset version`
-2. **Update lockfile**: `pnpm install`
-3. **Build all packages**: `pnpm build`
-4. **Run tests**: `pnpm test`
-5. **Publish**: `pnpm changeset publish`
+1. **Version bump**: `corepack pnpm@9.6.0 changeset version`
+2. **Update lockfile**: `corepack pnpm@9.6.0 install`
+3. **Build all packages**: `corepack pnpm@9.6.0 build`
+4. **Run tests**: `corepack pnpm@9.6.0 test`
+5. **Publish**: `corepack pnpm@9.6.0 changeset publish`
 6. **Create release notes**: Automatic via changesets
 
 ## Branch Naming


### PR DESCRIPTION
## Description
- Pins root contributor command examples to `corepack pnpm@9.6.0` so they match the root `packageManager`/`engines` constraints.
- Updates the package contributor supplement with the same pinned Corepack command pattern.

## Related Issue
None.

## Type of Change
- [x] Documentation update

## Affected Package(s)
- [x] Repository/tooling

## Checklist
- [x] I have read the Contributing Guidelines
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
- [x] Changeset not needed: docs-only contributor guidance

## Tests
- `corepack pnpm@9.0.0 --filter @opensourceframework/next-iron-session test` (expected failure: root requires pnpm >=9.6.0)
- `corepack pnpm@9.6.0 lint`
- `corepack pnpm@9.6.0 typecheck`
- `corepack pnpm@9.6.0 test`
- `corepack pnpm@9.6.0 exec prettier --check CONTRIBUTING.md packages/CONTRIBUTING.md`
- `git diff --check`
- staged secret scan