### PR TITLE
fix(codemods): report package CLI version

### DIFF
--- a/packages/codemods/__tests__/cli.test.js
+++ b/packages/codemods/__tests__/cli.test.js
@@ -1,0 +1,18 @@
+import { execFileSync } from 'child_process';
+import path from 'path';
+import { fileURLToPath } from 'url';
+import { describe, expect, it } from 'vitest';
+import packageJson from '../package.json';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+
+describe('osf-codemod CLI', () => {
+  it('reports the package version', () => {
+    const binPath = path.join(__dirname, '../bin/osf-codemod.js');
+    const output = execFileSync(process.execPath, [binPath, '--version'], {
+      encoding: 'utf8',
+    }).trim();
+
+    expect(output).toBe(packageJson.version);
+  });
+});

--- a/packages/codemods/bin/osf-codemod.js
+++ b/packages/codemods/bin/osf-codemod.js
@@ -4,11 +4,12 @@ const { program } = require('commander');
 const { execSync } = require('child_process');
 const path = require('path');
 const fs = require('fs');
+const { version } = require('../package.json');
 
 program
   .name('osf-codemod')
   .description('CLI to run OpenSource Framework codemods')
-  .version('0.1.0');
+  .version(version);
 
 program
   .command('next-seo')


### PR DESCRIPTION
## Summary
- fixes osf-codemod --version to read from package.json instead of a stale hardcoded value
- adds a regression test that compares CLI output with the package version

## Tests
- corepack pnpm@9.6.0 --filter @opensourceframework/codemods test
- corepack pnpm@9.6.0 --filter @opensourceframework/codemods build
- node packages/codemods/bin/osf-codemod.js --version
- git diff --check