### PR TITLE
fix(next-iron-session): restore cookie priority type build

### DIFF
--- a/packages/next-iron-session/CONTRIBUTING.md
+++ b/packages/next-iron-session/CONTRIBUTING.md
@@ -6,22 +6,25 @@ the following guide:
 
 ## Repository Setup
 
+This package is maintained inside the OpenSourceFramework monorepo. Use the
+root-pinned pnpm version so package scripts match CI and the lockfile:
+
 ```sh
 fnm install
 corepack enable
-pnpm install
+corepack pnpm@9.6.0 install
 ```
 
 ## Development
 
 ```sh
-pnpm dev
+corepack pnpm@9.6.0 --filter @opensourceframework/next-iron-session dev
 ```
 
 ## Tests
 
 ```sh
-pnpm test
+corepack pnpm@9.6.0 --filter @opensourceframework/next-iron-session test
 ```
 
 ## Submitting a Contribution

--- a/packages/next-iron-session/src/core.ts
+++ b/packages/next-iron-session/src/core.ts
@@ -31,9 +31,15 @@ interface CookieListItem
 /**
  * Superset of {@link CookieListItem} extending it with
  * the `httpOnly`, `maxAge` and `priority` properties.
+ *
+ * `cookie@0.7` serializes the Priority attribute at runtime, but its DefinitelyTyped
+ * definitions do not expose that option yet. Keep the Next-compatible cookie store
+ * type explicit instead of depending on a missing `CookieSerializeOptions` key.
  */
 type ResponseCookie = CookieListItem &
-  Pick<CookieSerializeOptions, "httpOnly" | "maxAge" | "priority">;
+  Pick<CookieSerializeOptions, "httpOnly" | "maxAge"> & {
+    priority?: "low" | "medium" | "high";
+  };
 
 /**
  * The high-level type definition of the .get() and .set() methods

--- a/packages/next-iron-session/src/core.ts
+++ b/packages/next-iron-session/src/core.ts
@@ -38,7 +38,7 @@ interface CookieListItem
  */
 type ResponseCookie = CookieListItem &
   Pick<CookieSerializeOptions, "httpOnly" | "maxAge"> & {
-    priority?: "low" | "medium" | "high";
+    priority?: "low" | "medium" | "high" | undefined;
   };
 
 /**


### PR DESCRIPTION
## Summary
- Fixes the next-iron-session DTS build by keeping the Next cookie `priority` option explicit instead of picking a missing key from `@types/cookie`.
- Updates the package contribution guide to use the repo-pinned pnpm 9.6.0/Corepack commands that match CI.

## Root cause
`cookie@0.7` supports the Priority attribute at runtime, but `@types/cookie@0.6.0` does not expose `priority` on `CookieSerializeOptions`, so `Pick<CookieSerializeOptions, 'priority'>` breaks declaration generation.

## Tests
- `corepack pnpm@9.6.0 --filter @opensourceframework/next-iron-session test`
- `corepack pnpm@9.6.0 --filter @opensourceframework/next-iron-session lint`
- `git diff --check`
- staged secret scan
