### PR TITLE
chore(react-virtualized): update Prettier config option

### DIFF
--- a/packages/react-virtualized/.prettierrc
+++ b/packages/react-virtualized/.prettierrc
@@ -1,6 +1,6 @@
 {
   "bracketSpacing": false,
-  "jsxBracketSameLine": true,
+  "bracketSameLine": true,
   "printWidth": 80,
   "singleQuote": true,
   "trailingComma": "all"


### PR DESCRIPTION
## Summary
- Replaces the deprecated `jsxBracketSameLine` Prettier option in the react-virtualized package config with `bracketSameLine`.
- Formats the package-local Prettier config so targeted checks pass cleanly.

## Tests
- `corepack pnpm@9.6.0 exec prettier --check 'packages/react-virtualized/.prettierrc'`
- `corepack pnpm@9.6.0 --filter @opensourceframework/react-virtualized lint`
- `corepack pnpm@9.6.0 --filter @opensourceframework/react-virtualized typecheck`
- Earlier maintenance checks on fresh worktree: `corepack pnpm@9.6.0 test`, `corepack pnpm@9.6.0 lint`, `corepack pnpm@9.6.0 typecheck`, `corepack pnpm@9.6.0 audit --audit-level high --json`