### PR TITLE
test(next-optimized-images): isolate loader detection

### DIFF
--- a/packages/next-optimized-images/__tests__/loaders/index.test.js
+++ b/packages/next-optimized-images/__tests__/loaders/index.test.js
@@ -6,21 +6,11 @@ const {
   appendLoaders,
 } = require('../../lib/loaders');
 const { getConfig } = require('../../lib/config');
-const Module = require('module');
+const fs = require('fs');
+const os = require('os');
 const path = require('path');
 
 const imageminPluginPath = path.join(__dirname, '../fixtures/imagemin-plugin.js');
-const optionalLoaderNames = new Set([
-  'imagemin-mozjpeg',
-  'imagemin-gifsicle',
-  'imagemin-svgo',
-  'svg-sprite-loader',
-  'webp-loader',
-  'lqip-loader',
-  'imagemin-optipng',
-  'imagemin-pngquant',
-  'responsive-loader',
-]);
 
 describe('next-optimized-images/loaders', () => {
   it('detects if a module is installed', () => {
@@ -31,21 +21,10 @@ describe('next-optimized-images/loaders', () => {
   });
 
   it('detects installed loaders', () => {
-    const originalResolveFilename = Module._resolveFilename;
-    const resolveSpy = vi.spyOn(Module, '_resolveFilename').mockImplementation(function (...args) {
-      const [request] = args;
-
-      if (optionalLoaderNames.has(request)) {
-        const error = new Error(`Cannot find module '${request}'`);
-        error.code = 'MODULE_NOT_FOUND';
-        throw error;
-      }
-
-      return originalResolveFilename.apply(this, args);
-    });
+    const emptyResolvePath = fs.mkdtempSync(path.join(os.tmpdir(), 'next-optimized-images-'));
 
     try {
-      expect(detectLoaders()).toEqual({
+      expect(detectLoaders(emptyResolvePath)).toEqual({
         jpeg: false,
         gif: false,
         svg: false,
@@ -57,7 +36,7 @@ describe('next-optimized-images/loaders', () => {
         responsiveAdapter: false,
       });
     } finally {
-      resolveSpy.mockRestore();
+      fs.rmSync(emptyResolvePath, { recursive: true, force: true });
     }
   });
 


### PR DESCRIPTION
## Summary
- isolates the loader-detection test from workspace-installed optional loaders
- replaces the brittle Module._resolveFilename mock with a temporary empty resolve path
- keeps the fixture cleanup scoped to the test

## Root cause
The previous test depended on intercepting optional-loader resolution globally. With optional loaders present in the workspace dependency graph, detectLoaders could observe real installed modules (for example svg-sprite-loader), making the expected all-false result environment-dependent.

## Tests
- corepack pnpm@9.6.0 --filter @opensourceframework/next-optimized-images test
- git diff --check