### PR TITLE
fix(codemods): avoid shell execution in cli

### DIFF
--- a/.changeset/clean-codemods-shells.md
+++ b/.changeset/clean-codemods-shells.md
@@ -1,0 +1,5 @@
+---
+'@opensourceframework/codemods': patch
+---
+
+Harden the codemod CLI against shell injection in migration paths and limit the published package contents to runtime files.

--- a/packages/codemods/__tests__/cli.test.js
+++ b/packages/codemods/__tests__/cli.test.js
@@ -1,4 +1,6 @@
 import { execFileSync } from 'child_process';
+import fs from 'fs';
+import os from 'os';
 import path from 'path';
 import { fileURLToPath } from 'url';
 import { describe, expect, it } from 'vitest';
@@ -14,5 +16,32 @@ describe('osf-codemod CLI', () => {
     }).trim();
 
     expect(output).toBe(packageJson.version);
+  });
+
+  it('passes migration paths as arguments instead of shell commands', () => {
+    const binPath = path.join(__dirname, '../bin/osf-codemod.js');
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'osf-codemod-'));
+    const markerPath = path.join(tmpDir, 'shell-injection-marker');
+    const targetName = 'target; touch shell-injection-marker; #';
+    const targetPath = path.join(tmpDir, targetName);
+
+    fs.mkdirSync(targetPath);
+
+    try {
+      try {
+        execFileSync(process.execPath, [binPath, 'next-seo', targetName], {
+          cwd: tmpDir,
+          encoding: 'utf8',
+          stdio: 'pipe',
+        });
+      } catch {
+        // The migration may fail because the fixture has no transformable files.
+        // This assertion is about ensuring the path was never evaluated by a shell.
+      }
+
+      expect(fs.existsSync(markerPath)).toBe(false);
+    } finally {
+      fs.rmSync(tmpDir, { recursive: true, force: true });
+    }
   });
 });

--- a/packages/codemods/bin/osf-codemod.js
+++ b/packages/codemods/bin/osf-codemod.js
@@ -1,9 +1,8 @@
 #!/usr/bin/env node
 
 const { program } = require('commander');
-const { execSync } = require('child_process');
+const { spawnSync } = require('child_process');
 const path = require('path');
-const fs = require('fs');
 const { version } = require('../package.json');
 
 program
@@ -18,13 +17,27 @@ program
   .action((dir) => {
     const transformPath = path.join(__dirname, '../src/transforms/next-seo-import.ts');
     const jscodeshiftExecutable = require.resolve('.bin/jscodeshift');
-    
+
     console.log(`Running next-seo migration on ${dir}...`);
-    
+
     try {
-      execSync(`${jscodeshiftExecutable} -t ${transformPath} ${dir} --extensions=ts,tsx,js,jsx`, {
-        stdio: 'inherit'
-      });
+      const result = spawnSync(
+        jscodeshiftExecutable,
+        ['-t', transformPath, dir, '--extensions=ts,tsx,js,jsx'],
+        {
+          stdio: 'inherit',
+          shell: false,
+        }
+      );
+
+      if (result.error) {
+        throw result.error;
+      }
+
+      if (result.status !== 0) {
+        process.exit(result.status ?? 1);
+      }
+
       console.log('✅ Migration complete!');
     } catch (error) {
       console.error('❌ Migration failed:', error.message);

--- a/packages/codemods/package.json
+++ b/packages/codemods/package.json
@@ -6,6 +6,13 @@
   "bin": {
     "osf-codemod": "bin/osf-codemod.js"
   },
+  "files": [
+    "bin",
+    "dist",
+    "src/transforms",
+    "README.md",
+    "CHANGELOG.md"
+  ],
   "scripts": {
     "build": "tsup",
     "test": "vitest run --passWithNoTests"


### PR DESCRIPTION
## Summary
- runs jscodeshift via spawnSync argv instead of shell-building a command from user paths
- adds a regression test for shell metacharacters in migration paths
- limits @opensourceframework/codemods package contents to runtime files while preserving the transform source required by the CLI
- adds a patch changeset

## Tests
- git diff --check
- corepack pnpm@9.6.0 exec prettier --check packages/codemods/package.json packages/codemods/bin/osf-codemod.js packages/codemods/__tests__/cli.test.js
- corepack pnpm@9.6.0 --filter @opensourceframework/codemods test
- corepack pnpm@9.6.0 --filter @opensourceframework/codemods build
- cd packages/codemods && npm pack --dry-run