### PR TITLE
docs: fix repository links

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 > Maintained forks of abandoned npm packages
 
 [![CI](https://github.com/riceharvest/opensourceframework/actions/workflows/ci.yml/badge.svg)](https://github.com/riceharvest/opensourceframework/actions/workflows/ci.yml)
-[![License](https://img.shields.io/github/license/opensourceframework/opensourceframework.svg)](./LICENSE)
+[![License](https://img.shields.io/github/license/riceharvest/opensourceframework.svg)](./LICENSE)
 [![Commitizen friendly](https://img.shields.io/badge/commitizen-friendly-brightgreen.svg)](http://commitizen.github.io/cz-cli/)
 
 ## About

--- a/docs/app/packages/critters/page.mdx
+++ b/docs/app/packages/critters/page.mdx
@@ -30,8 +30,7 @@ pnpm add @opensourceframework/critters
 ## Usage
 
 ```javascript
-// Example usage - will be updated when implementation is complete
-import { /* exports */ } from '@opensourceframework/critters';
+import Critters from '@opensourceframework/critters';
 ```
 
 ## Documentation
@@ -49,5 +48,5 @@ MIT © OpenSource Framework Contributors
 ## Links
 
 - [Original Package](https://www.npmjs.com/package/critters)
-- [Issue Tracker](https://github.com/opensourceframework/opensourceframework/issues)
+- [Issue Tracker](https://github.com/riceharvest/opensourceframework/issues)
 - [Changelog](./CHANGELOG.md)

--- a/packages/critters/README.md
+++ b/packages/critters/README.md
@@ -30,8 +30,7 @@ pnpm add @opensourceframework/critters
 ## Usage
 
 ```javascript
-// Example usage - will be updated when implementation is complete
-import { /* exports */ } from '@opensourceframework/critters';
+import Critters from '@opensourceframework/critters';
 ```
 
 ## Documentation
@@ -49,5 +48,5 @@ MIT © OpenSource Framework Contributors
 ## Links
 
 - [Original Package](https://www.npmjs.com/package/critters)
-- [Issue Tracker](https://github.com/opensourceframework/opensourceframework/issues)
+- [Issue Tracker](https://github.com/riceharvest/opensourceframework/issues)
 - [Changelog](./CHANGELOG.md)

--- a/packages/critters/SECURITY.md
+++ b/packages/critters/SECURITY.md
@@ -23,7 +23,7 @@ Given that we maintain security-critical packages like `next-csrf`, we take secu
 
 Instead, please report them through GitHub Security Advisories:
 
-1. Go to the [Security Advisories page](https://github.com/opensourceframework/opensourceframework/security/advisories/new)
+1. Go to the [Security Advisories page](https://github.com/riceharvest/opensourceframework/security/advisories/new)
 2. Click "Report a vulnerability"
 3. Fill out the form with details about the vulnerability
 

--- a/packages/next-circuit-breaker/SECURITY.md
+++ b/packages/next-circuit-breaker/SECURITY.md
@@ -23,7 +23,7 @@ Given that we maintain security-critical packages like `next-csrf`, we take secu
 
 Instead, please report them through GitHub Security Advisories:
 
-1. Go to the [Security Advisories page](https://github.com/opensourceframework/opensourceframework/security/advisories/new)
+1. Go to the [Security Advisories page](https://github.com/riceharvest/opensourceframework/security/advisories/new)
 2. Click "Report a vulnerability"
 3. Fill out the form with details about the vulnerability
 

--- a/packages/next-csrf/SECURITY.md
+++ b/packages/next-csrf/SECURITY.md
@@ -23,7 +23,7 @@ Given that we maintain security-critical packages like `next-csrf`, we take secu
 
 Instead, please report them through GitHub Security Advisories:
 
-1. Go to the [Security Advisories page](https://github.com/opensourceframework/opensourceframework/security/advisories/new)
+1. Go to the [Security Advisories page](https://github.com/riceharvest/opensourceframework/security/advisories/new)
 2. Click "Report a vulnerability"
 3. Fill out the form with details about the vulnerability
 

--- a/packages/next-images/SECURITY.md
+++ b/packages/next-images/SECURITY.md
@@ -23,7 +23,7 @@ Given that we maintain security-critical packages like `next-csrf`, we take secu
 
 Instead, please report them through GitHub Security Advisories:
 
-1. Go to the [Security Advisories page](https://github.com/opensourceframework/opensourceframework/security/advisories/new)
+1. Go to the [Security Advisories page](https://github.com/riceharvest/opensourceframework/security/advisories/new)
 2. Click "Report a vulnerability"
 3. Fill out the form with details about the vulnerability
 

--- a/packages/next-json-ld/SECURITY.md
+++ b/packages/next-json-ld/SECURITY.md
@@ -23,7 +23,7 @@ Given that we maintain security-critical packages like `next-csrf`, we take secu
 
 Instead, please report them through GitHub Security Advisories:
 
-1. Go to the [Security Advisories page](https://github.com/opensourceframework/opensourceframework/security/advisories/new)
+1. Go to the [Security Advisories page](https://github.com/riceharvest/opensourceframework/security/advisories/new)
 2. Click "Report a vulnerability"
 3. Fill out the form with details about the vulnerability
 

--- a/packages/react-a11y-utils/SECURITY.md
+++ b/packages/react-a11y-utils/SECURITY.md
@@ -23,7 +23,7 @@ Given that we maintain security-critical packages like `next-csrf`, we take secu
 
 Instead, please report them through GitHub Security Advisories:
 
-1. Go to the [Security Advisories page](https://github.com/opensourceframework/opensourceframework/security/advisories/new)
+1. Go to the [Security Advisories page](https://github.com/riceharvest/opensourceframework/security/advisories/new)
 2. Click "Report a vulnerability"
 3. Fill out the form with details about the vulnerability
 

--- a/packages/seeded-rng/SECURITY.md
+++ b/packages/seeded-rng/SECURITY.md
@@ -23,7 +23,7 @@ Given that we maintain security-critical packages like `next-csrf`, we take secu
 
 Instead, please report them through GitHub Security Advisories:
 
-1. Go to the [Security Advisories page](https://github.com/opensourceframework/opensourceframework/security/advisories/new)
+1. Go to the [Security Advisories page](https://github.com/riceharvest/opensourceframework/security/advisories/new)
 2. Click "Report a vulnerability"
 3. Fill out the form with details about the vulnerability
 


### PR DESCRIPTION
## Summary
- Updates public docs, package READMEs, and SECURITY.md files that pointed at the non-existent opensourceframework/opensourceframework GitHub repo.
- Points issue/security links and the root license badge at the actual riceharvest/opensourceframework repository.
- Replaces the stale critters placeholder import snippet with the package's real default import.

## Tests
- corepack pnpm@9.6.0 exec prettier --check README.md docs/app/packages/critters/page.mdx packages/critters/README.md packages/critters/SECURITY.md packages/next-circuit-breaker/SECURITY.md packages/next-csrf/SECURITY.md packages/next-images/SECURITY.md packages/next-json-ld/SECURITY.md packages/react-a11y-utils/SECURITY.md packages/seeded-rng/SECURITY.md
- git diff --check
- corepack pnpm@9.6.0 --filter @opensourceframework/critters test