### PR TITLE
docs: fix mojibake in contributing guides

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -182,16 +182,16 @@ chore(deps): update typescript to v5.4.0
 
 ```
 packages/[package-name]/
-â src/
-â  â index.ts          # Public exports
-â  â [module].ts       # Module implementations
-â  â __tests__/        # Test files (co-located)
-â test/
-â  â index.test.ts     # Integration tests
-â package.json
-â tsconfig.json
-â tsup.config.ts
-â vitest.config.ts
+├ src/
+│  ├ index.ts          # Public exports
+│  ├ [module].ts       # Module implementations
+│  └ __tests__/        # Test files (co-located)
+├ test/
+│  └ index.test.ts     # Integration tests
+├ package.json
+├ tsconfig.json
+├ tsup.config.ts
+└ vitest.config.ts
 ```
 
 ## Testing Requirements
@@ -327,4 +327,4 @@ export function generateToken(options?: { length?: number }): string {
 - **Bugs?** Open an issue with the bug template
 - **Security issues?** Follow our [Security Policy](./SECURITY.md)
 
-Thank you for contributing to OpenSource Framework! ð
+Thank you for contributing to OpenSource Framework! 🎉

--- a/packages/critters/CONTRIBUTING.md
+++ b/packages/critters/CONTRIBUTING.md
@@ -182,16 +182,16 @@ chore(deps): update typescript to v5.4.0
 
 ```
 packages/[package-name]/
-â src/
-â  â index.ts          # Public exports
-â  â [module].ts       # Module implementations
-â  â __tests__/        # Test files (co-located)
-â test/
-â  â index.test.ts     # Integration tests
-â package.json
-â tsconfig.json
-â tsup.config.ts
-â vitest.config.ts
+├ src/
+│  ├ index.ts          # Public exports
+│  ├ [module].ts       # Module implementations
+│  └ __tests__/        # Test files (co-located)
+├ test/
+│  └ index.test.ts     # Integration tests
+├ package.json
+├ tsconfig.json
+├ tsup.config.ts
+└ vitest.config.ts
 ```
 
 ## Testing Requirements
@@ -327,4 +327,4 @@ export function generateToken(options?: { length?: number }): string {
 - **Bugs?** Open an issue with the bug template
 - **Security issues?** Follow our [Security Policy](./SECURITY.md)
 
-Thank you for contributing to OpenSource Framework! ð
+Thank you for contributing to OpenSource Framework! 🎉

--- a/packages/next-circuit-breaker/CONTRIBUTING.md
+++ b/packages/next-circuit-breaker/CONTRIBUTING.md
@@ -182,16 +182,16 @@ chore(deps): update typescript to v5.4.0
 
 ```
 packages/[package-name]/
-â src/
-â  â index.ts          # Public exports
-â  â [module].ts       # Module implementations
-â  â __tests__/        # Test files (co-located)
-â test/
-â  â index.test.ts     # Integration tests
-â package.json
-â tsconfig.json
-â tsup.config.ts
-â vitest.config.ts
+├ src/
+│  ├ index.ts          # Public exports
+│  ├ [module].ts       # Module implementations
+│  └ __tests__/        # Test files (co-located)
+├ test/
+│  └ index.test.ts     # Integration tests
+├ package.json
+├ tsconfig.json
+├ tsup.config.ts
+└ vitest.config.ts
 ```
 
 ## Testing Requirements
@@ -327,4 +327,4 @@ export function generateToken(options?: { length?: number }): string {
 - **Bugs?** Open an issue with the bug template
 - **Security issues?** Follow our [Security Policy](./SECURITY.md)
 
-Thank you for contributing to OpenSource Framework! ð
+Thank you for contributing to OpenSource Framework! 🎉

--- a/packages/next-csrf/CONTRIBUTING.md
+++ b/packages/next-csrf/CONTRIBUTING.md
@@ -182,16 +182,16 @@ chore(deps): update typescript to v5.4.0
 
 ```
 packages/[package-name]/
-â src/
-â  â index.ts          # Public exports
-â  â [module].ts       # Module implementations
-â  â __tests__/        # Test files (co-located)
-â test/
-â  â index.test.ts     # Integration tests
-â package.json
-â tsconfig.json
-â tsup.config.ts
-â vitest.config.ts
+├ src/
+│  ├ index.ts          # Public exports
+│  ├ [module].ts       # Module implementations
+│  └ __tests__/        # Test files (co-located)
+├ test/
+│  └ index.test.ts     # Integration tests
+├ package.json
+├ tsconfig.json
+├ tsup.config.ts
+└ vitest.config.ts
 ```
 
 ## Testing Requirements
@@ -327,4 +327,4 @@ export function generateToken(options?: { length?: number }): string {
 - **Bugs?** Open an issue with the bug template
 - **Security issues?** Follow our [Security Policy](./SECURITY.md)
 
-Thank you for contributing to OpenSource Framework! ð
+Thank you for contributing to OpenSource Framework! 🎉

--- a/packages/next-images/CONTRIBUTING.md
+++ b/packages/next-images/CONTRIBUTING.md
@@ -182,16 +182,16 @@ chore(deps): update typescript to v5.4.0
 
 ```
 packages/[package-name]/
-â src/
-â  â index.ts          # Public exports
-â  â [module].ts       # Module implementations
-â  â __tests__/        # Test files (co-located)
-â test/
-â  â index.test.ts     # Integration tests
-â package.json
-â tsconfig.json
-â tsup.config.ts
-â vitest.config.ts
+├ src/
+│  ├ index.ts          # Public exports
+│  ├ [module].ts       # Module implementations
+│  └ __tests__/        # Test files (co-located)
+├ test/
+│  └ index.test.ts     # Integration tests
+├ package.json
+├ tsconfig.json
+├ tsup.config.ts
+└ vitest.config.ts
 ```
 
 ## Testing Requirements
@@ -327,4 +327,4 @@ export function generateToken(options?: { length?: number }): string {
 - **Bugs?** Open an issue with the bug template
 - **Security issues?** Follow our [Security Policy](./SECURITY.md)
 
-Thank you for contributing to OpenSource Framework! ð
+Thank you for contributing to OpenSource Framework! 🎉

--- a/packages/next-json-ld/CONTRIBUTING.md
+++ b/packages/next-json-ld/CONTRIBUTING.md
@@ -182,16 +182,16 @@ chore(deps): update typescript to v5.4.0
 
 ```
 packages/[package-name]/
-â src/
-â  â index.ts          # Public exports
-â  â [module].ts       # Module implementations
-â  â __tests__/        # Test files (co-located)
-â test/
-â  â index.test.ts     # Integration tests
-â package.json
-â tsconfig.json
-â tsup.config.ts
-â vitest.config.ts
+├ src/
+│  ├ index.ts          # Public exports
+│  ├ [module].ts       # Module implementations
+│  └ __tests__/        # Test files (co-located)
+├ test/
+│  └ index.test.ts     # Integration tests
+├ package.json
+├ tsconfig.json
+├ tsup.config.ts
+└ vitest.config.ts
 ```
 
 ## Testing Requirements
@@ -327,4 +327,4 @@ export function generateToken(options?: { length?: number }): string {
 - **Bugs?** Open an issue with the bug template
 - **Security issues?** Follow our [Security Policy](./SECURITY.md)
 
-Thank you for contributing to OpenSource Framework! ð
+Thank you for contributing to OpenSource Framework! 🎉

--- a/packages/react-a11y-utils/CONTRIBUTING.md
+++ b/packages/react-a11y-utils/CONTRIBUTING.md
@@ -182,16 +182,16 @@ chore(deps): update typescript to v5.4.0
 
 ```
 packages/[package-name]/
-â src/
-â  â index.ts          # Public exports
-â  â [module].ts       # Module implementations
-â  â __tests__/        # Test files (co-located)
-â test/
-â  â index.test.ts     # Integration tests
-â package.json
-â tsconfig.json
-â tsup.config.ts
-â vitest.config.ts
+├ src/
+│  ├ index.ts          # Public exports
+│  ├ [module].ts       # Module implementations
+│  └ __tests__/        # Test files (co-located)
+├ test/
+│  └ index.test.ts     # Integration tests
+├ package.json
+├ tsconfig.json
+├ tsup.config.ts
+└ vitest.config.ts
 ```
 
 ## Testing Requirements
@@ -327,4 +327,4 @@ export function generateToken(options?: { length?: number }): string {
 - **Bugs?** Open an issue with the bug template
 - **Security issues?** Follow our [Security Policy](./SECURITY.md)
 
-Thank you for contributing to OpenSource Framework! ð
+Thank you for contributing to OpenSource Framework! 🎉

--- a/packages/seeded-rng/CONTRIBUTING.md
+++ b/packages/seeded-rng/CONTRIBUTING.md
@@ -182,16 +182,16 @@ chore(deps): update typescript to v5.4.0
 
 ```
 packages/[package-name]/
-â src/
-â  â index.ts          # Public exports
-â  â [module].ts       # Module implementations
-â  â __tests__/        # Test files (co-located)
-â test/
-â  â index.test.ts     # Integration tests
-â package.json
-â tsconfig.json
-â tsup.config.ts
-â vitest.config.ts
+├ src/
+│  ├ index.ts          # Public exports
+│  ├ [module].ts       # Module implementations
+│  └ __tests__/        # Test files (co-located)
+├ test/
+│  └ index.test.ts     # Integration tests
+├ package.json
+├ tsconfig.json
+├ tsup.config.ts
+└ vitest.config.ts
 ```
 
 ## Testing Requirements
@@ -327,4 +327,4 @@ export function generateToken(options?: { length?: number }): string {
 - **Bugs?** Open an issue with the bug template
 - **Security issues?** Follow our [Security Policy](./SECURITY.md)
 
-Thank you for contributing to OpenSource Framework! ð
+Thank you for contributing to OpenSource Framework! 🎉

--- a/templates/CONTRIBUTING.template.md
+++ b/templates/CONTRIBUTING.template.md
@@ -163,4 +163,4 @@ packages/{package-name}/
 - **Bugs?** Open an [Issue](https://github.com/riceharvest/opensourceframework/issues)
 - **Security?** See our [Security Policy](./SECURITY.md)
 
-Thank you for contributing! ðŸŽ‰
+Thank you for contributing! 🎉


### PR DESCRIPTION
## Summary
- Replaces mojibake tree glyphs in the root and copied package CONTRIBUTING guides with readable box-drawing characters
- Fixes the corrupted celebration emoji in the contributing template and generated guides

## Tests run
- Mojibake scan over CONTRIBUTING guides/template
- corepack pnpm@9.6.0 exec prettier --check CONTRIBUTING.md packages/critters/CONTRIBUTING.md packages/next-circuit-breaker/CONTRIBUTING.md packages/next-csrf/CONTRIBUTING.md packages/next-images/CONTRIBUTING.md packages/next-json-ld/CONTRIBUTING.md packages/react-a11y-utils/CONTRIBUTING.md packages/seeded-rng/CONTRIBUTING.md templates/CONTRIBUTING.template.md
- git diff --check