### PR TITLE
fix(turn-based-game-engine): apply armor durability damage

### DIFF
--- a/.changeset/fix-turn-engine-armor-durability.md
+++ b/.changeset/fix-turn-engine-armor-durability.md
@@ -1,0 +1,5 @@
+---
+'@opensourceframework/turn-based-game-engine': patch
+---
+
+Return raid stash updates so equipped armor durability damage is applied after combat ticks.

--- a/packages/turn-based-game-engine/src/engine.ts
+++ b/packages/turn-based-game-engine/src/engine.ts
@@ -591,7 +591,8 @@ function processRaidTick(
 ): RaidProcessResult {
     const events: GameEvent[] = [];
     const raidUpdates: Partial<ActiveRaid> = {
-        elapsedTime: raid.elapsedTime + dt
+        elapsedTime: raid.elapsedTime + dt,
+        raidLogs: [...raid.raidLogs]
     };
     // Only collect new logs, apply at end
     const newLogs: string[] = [];
@@ -810,7 +811,11 @@ function processRaidTick(
         }
     }
 
-    return { raidUpdates, playerStatsUpdates: playerStatsUpdates ?? undefined, events };
+    if (newLogs.length > 0) {
+        raidUpdates.raidLogs = [...(raidUpdates.raidLogs ?? raid.raidLogs), ...newLogs];
+    }
+
+    return { raidUpdates, playerStatsUpdates: playerStatsUpdates ?? undefined, stashUpdates, events };
 }
 
 function formatTime(s: number): string {

--- a/packages/turn-based-game-engine/test/index.test.ts
+++ b/packages/turn-based-game-engine/test/index.test.ts
@@ -112,6 +112,64 @@ describe('@opensourceframework/turn-based-game-engine', () => {
     vi.useRealTimers();
   });
 
+  it('returns armor durability updates when equipped armor is damaged in combat', () => {
+    vi.useFakeTimers({ now: new Date('2026-01-01T00:00:00.000Z') });
+    const randomSpy = vi
+      .spyOn(Math, 'random')
+      .mockReturnValueOnce(0.99) // player misses
+      .mockReturnValueOnce(0) // enemy attacks
+      .mockReturnValueOnce(0.99) // player does not dodge
+      .mockReturnValueOnce(0); // hit head
+
+    const state = createMinimalGameState({
+      activeRaid: {
+        locationId: 'factory',
+        startTime: Date.now(),
+        elapsedTime: 0,
+        status: 'combat',
+        currentEnemy: { id: 'scav-basic', hp: 100, maxHp: 100 },
+        lootFound: [],
+        raidLogs: [],
+        isScav: false,
+        seed: 1,
+      },
+      equipment: { bodyArmor: 'armor-1', primary: 'weapon-1' },
+      stash: [
+        {
+          instanceId: 'weapon-1',
+          itemId: 'ak-74',
+          x: 0,
+          y: 0,
+          rotated: false,
+          quantity: 1,
+          foundInRaid: false,
+        },
+        {
+          instanceId: 'armor-1',
+          itemId: 'paca',
+          x: 0,
+          y: 0,
+          rotated: false,
+          quantity: 1,
+          foundInRaid: false,
+          durability: 100,
+          maxDurability: 100,
+        },
+      ],
+    });
+
+    vi.advanceTimersByTime(1000);
+    const result = processTick(state);
+
+    expect(result.updates.stash?.find(item => item.instanceId === 'armor-1')?.durability).toBe(
+      93
+    );
+    expect(state.stash.find(item => item.instanceId === 'armor-1')?.durability).toBe(100);
+
+    randomSpy.mockRestore();
+    vi.useRealTimers();
+  });
+
   it('keeps ballistics utilities available from the public entrypoint', () => {
     expect(calculateFirstShotRecoil(10)).toBeGreaterThan(1);
   });


### PR DESCRIPTION
## Summary
- returns raid stash updates from combat tick processing so equipped armor durability damage reaches game state
- initializes raid log updates before combat/loot log writes and preserves queued encounter logs
- adds a regression test for immutable armor durability damage during combat
- adds a patch changeset for @opensourceframework/turn-based-game-engine

## Tests
- corepack pnpm@9.6.0 --filter @opensourceframework/turn-based-game-engine test
- corepack pnpm@9.6.0 --filter @opensourceframework/turn-based-game-engine typecheck
- corepack pnpm@9.6.0 --filter @opensourceframework/turn-based-game-engine lint (passes with existing warnings)
- corepack pnpm@9.6.0 --filter @opensourceframework/turn-based-game-engine build
- git diff --check
- staged secret scan