### PR TITLE
docs(templates): pin pnpm commands to corepack

### DIFF
--- a/templates/CONTRIBUTING.template.md
+++ b/templates/CONTRIBUTING.template.md
@@ -38,17 +38,17 @@ Thank you for your interest in contributing to @opensourceframework/{package-nam
 
 2. **Install dependencies**
    ```bash
-   pnpm install
+   corepack pnpm@9.6.0 install
    ```
 
 3. **Build the package**
    ```bash
-   pnpm --filter @opensourceframework/{package-name} build
+   corepack pnpm@9.6.0 --filter @opensourceframework/{package-name} build
    ```
 
 4. **Run tests**
    ```bash
-   pnpm --filter @opensourceframework/{package-name} test
+   corepack pnpm@9.6.0 --filter @opensourceframework/{package-name} test
    ```
 
 ## Development Workflow
@@ -88,7 +88,7 @@ test({package-name}): add integration tests for edge cases
 For any user-facing changes, create a changeset:
 
 ```bash
-pnpm changeset
+corepack pnpm@9.6.0 changeset
 ```
 
 Select:
@@ -106,16 +106,16 @@ Select:
 Run tests:
 ```bash
 # All tests for this package
-pnpm --filter @opensourceframework/{package-name} test
+corepack pnpm@9.6.0 --filter @opensourceframework/{package-name} test
 
 # Watch mode
-pnpm --filter @opensourceframework/{package-name} test:watch
+corepack pnpm@9.6.0 --filter @opensourceframework/{package-name} test:watch
 
 # Coverage
-pnpm --filter @opensourceframework/{package-name} test:coverage
+corepack pnpm@9.6.0 --filter @opensourceframework/{package-name} test:coverage
 
 # Type checking
-pnpm --filter @opensourceframework/{package-name} typecheck
+corepack pnpm@9.6.0 --filter @opensourceframework/{package-name} typecheck
 ```
 
 ### Pull Request Process

--- a/templates/README.template.md
+++ b/templates/README.template.md
@@ -72,22 +72,22 @@ If you're migrating from the original `{original-name}` package:
 
 ```bash
 # Install dependencies
-pnpm install
+corepack pnpm@9.6.0 install
 
 # Build the package
-pnpm build
+corepack pnpm@9.6.0 build
 
 # Run tests
-pnpm test
+corepack pnpm@9.6.0 test
 
 # Run tests with coverage
-pnpm test:coverage
+corepack pnpm@9.6.0 test:coverage
 
 # Type checking
-pnpm typecheck
+corepack pnpm@9.6.0 typecheck
 
 # Linting
-pnpm lint
+corepack pnpm@9.6.0 lint
 ```
 
 ## Security Considerations

--- a/templates/SECURITY.template.md
+++ b/templates/SECURITY.template.md
@@ -40,9 +40,9 @@ Please include the following information in your report:
 
 When using @opensourceframework packages, please follow these security best practices:
 
-1. **Keep dependencies updated**: Regularly run `pnpm update` to get the latest security patches.
+1. **Keep dependencies updated**: Regularly run `corepack pnpm@9.6.0 update` to get the latest security patches.
 2. **Use environment variables**: Never hardcode secrets in your code. Use environment variables for sensitive configuration.
-3. **Review dependencies**: Regularly audit your dependencies with `pnpm audit`.
+3. **Review dependencies**: Regularly audit your dependencies with `corepack pnpm@9.6.0 audit`.
 4. **Enable HTTPS**: Use HTTPS in production, especially for cookie-based security features.
 5. **Follow principle of least privilege**: Configure packages with minimal necessary permissions.
 


### PR DESCRIPTION
## Summary
- updates package README/contributing/security templates to use the repo-pinned pnpm 9.6.0 via Corepack
- keeps generated package docs aligned with root README/CONTRIBUTING guidance and avoids local pnpm-version mismatches

## Tests
- git diff --check
- corepack pnpm@9.6.0 exec prettier --check templates/README.template.md templates/CONTRIBUTING.template.md templates/SECURITY.template.md
- corepack pnpm@9.6.0 audit --audit-level=moderate
- corepack pnpm@9.6.0 test
- corepack pnpm@9.6.0 lint
- corepack pnpm@9.6.0 typecheck
- corepack pnpm@9.6.0 build