### PR TITLE
fix(next-iron-session): silence declaration build warning

### DIFF
--- a/.changeset/clean-horses-tell.md
+++ b/.changeset/clean-horses-tell.md
@@ -1,0 +1,5 @@
+---
+"@opensourceframework/next-iron-session": patch
+---
+
+Fix declaration builds to avoid Node HTTP type export warnings.

--- a/packages/next-iron-session/tsup.config.ts
+++ b/packages/next-iron-session/tsup.config.ts
@@ -4,8 +4,7 @@ export default defineConfig([
   {
     entry: ["src/index.ts"],
     clean: true,
-    // this setting inlines the types from dependencies we use, like `cookie`
-    dts: { resolve: true },
+    dts: true,
     format: ["esm", "cjs"],
     treeshake: true,
     sourcemap: true,


### PR DESCRIPTION
## Summary
- Switch next-iron-session tsup declaration generation from resolved DTS bundling to standard DTS generation
- Removes the Node HTTP type export warnings during package builds
- Adds a patch changeset for the published package

## Tests
- corepack pnpm@9.6.0 --filter @opensourceframework/next-iron-session test
- corepack pnpm@9.6.0 --filter @opensourceframework/next-iron-session lint
- git diff --check
- staged changed-line secret scan