### PR TITLE
fix(turbo): pass temporary directory env to tasks

### DIFF
--- a/turbo.json
+++ b/turbo.json
@@ -2,6 +2,7 @@
   "$schema": "https://turbo.build/schema.json",
   "globalDependencies": ["**/.env.*local"],
   "globalEnv": ["NODE_ENV"],
+  "globalPassThroughEnv": ["TMPDIR", "TMP", "TEMP"],
   "tasks": {
     "build": {
       "dependsOn": ["^build"],


### PR DESCRIPTION
## Summary
- Adds TMPDIR/TMP/TEMP to Turbo's global pass-through environment so package tasks honor caller-provided temp directories.
- Prevents Vitest/Turbo test runs from falling back to an exhausted system /tmp when a usable temp dir is explicitly set.

## Root cause
Turbo strict environment filtering was dropping TMPDIR before running package tasks. Direct Vitest runs honored TMPDIR, but Turbo-launched Vitest tasks still attempted to create worker temp folders under /tmp and failed with ENOSPC.

## Tests
- git diff --check
- TMPDIR=/home/dario/.hermes/tmp/vitest-tmp corepack pnpm@9.6.0 exec turbo run test --filter @opensourceframework/next-auth --force
- TMPDIR=/home/dario/.hermes/tmp/vitest-tmp corepack pnpm@9.6.0 lint
- TMPDIR=/home/dario/.hermes/tmp/vitest-tmp corepack pnpm@9.6.0 test