### PR TITLE
chore(tools): add package publication metadata

### DIFF
--- a/.changeset/clean-tools-publish-metadata.md
+++ b/.changeset/clean-tools-publish-metadata.md
@@ -1,0 +1,7 @@
+---
+"@opensourceframework/eslint-config": patch
+"@opensourceframework/prettier-config": patch
+"@opensourceframework/tsconfig": patch
+---
+
+Add package metadata for the shared tooling packages so npm publication includes license, repository, issue, homepage, and public access information.

--- a/tools/eslint-config/package.json
+++ b/tools/eslint-config/package.json
@@ -2,6 +2,8 @@
   "name": "@opensourceframework/eslint-config",
   "version": "1.0.0",
   "private": false,
+  "description": "Shared ESLint flat config for OpenSourceFramework packages",
+  "license": "MIT",
   "main": "index.js",
   "exports": {
     ".": "./index.js",
@@ -20,6 +22,18 @@
   "dependencies": {
     "@eslint/js": "^9.0.0",
     "eslint-config-prettier": "^9.0.0"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/riceharvest/opensourceframework.git",
+    "directory": "tools/eslint-config"
+  },
+  "bugs": {
+    "url": "https://github.com/riceharvest/opensourceframework/issues?q=is%3Aissue+is%3Aopen+eslint-config"
+  },
+  "homepage": "https://github.com/riceharvest/opensourceframework/tree/main/tools/eslint-config#readme",
+  "publishConfig": {
+    "access": "public"
   },
   "devDependencies": {
     "@typescript-eslint/eslint-plugin": "^8.56.1",

--- a/tools/prettier-config/package.json
+++ b/tools/prettier-config/package.json
@@ -2,6 +2,8 @@
   "name": "@opensourceframework/prettier-config",
   "version": "1.0.0",
   "private": false,
+  "description": "Shared Prettier config for OpenSourceFramework packages",
+  "license": "MIT",
   "main": "index.js",
   "exports": {
     ".": "./index.js"
@@ -11,6 +13,18 @@
   ],
   "peerDependencies": {
     "prettier": "^3.0.0"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/riceharvest/opensourceframework.git",
+    "directory": "tools/prettier-config"
+  },
+  "bugs": {
+    "url": "https://github.com/riceharvest/opensourceframework/issues?q=is%3Aissue+is%3Aopen+prettier-config"
+  },
+  "homepage": "https://github.com/riceharvest/opensourceframework/tree/main/tools/prettier-config#readme",
+  "publishConfig": {
+    "access": "public"
   },
   "devDependencies": {
     "@typescript-eslint/eslint-plugin": "^8.56.1",

--- a/tools/tsconfig/package.json
+++ b/tools/tsconfig/package.json
@@ -2,6 +2,8 @@
   "name": "@opensourceframework/tsconfig",
   "version": "1.0.0",
   "private": false,
+  "description": "Shared TypeScript config presets for OpenSourceFramework packages",
+  "license": "MIT",
   "main": "index.json",
   "exports": {
     ".": "./index.json",
@@ -11,6 +13,18 @@
   "files": [
     "*.json"
   ],
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/riceharvest/opensourceframework.git",
+    "directory": "tools/tsconfig"
+  },
+  "bugs": {
+    "url": "https://github.com/riceharvest/opensourceframework/issues?q=is%3Aissue+is%3Aopen+tsconfig"
+  },
+  "homepage": "https://github.com/riceharvest/opensourceframework/tree/main/tools/tsconfig#readme",
+  "publishConfig": {
+    "access": "public"
+  },
   "devDependencies": {
     "@typescript-eslint/eslint-plugin": "^8.56.1",
     "@typescript-eslint/parser": "^8.56.1",


### PR DESCRIPTION
## Summary
- Adds license, description, repository, bugs, homepage, and public publishConfig metadata to the shared tooling packages.
- Adds a changeset for @opensourceframework/eslint-config, @opensourceframework/prettier-config, and @opensourceframework/tsconfig.

## Tests
- corepack pnpm@9.6.0 exec prettier --check tools/eslint-config/package.json tools/prettier-config/package.json tools/tsconfig/package.json .changeset/clean-tools-publish-metadata.md
- corepack pnpm@9.6.0 lint
- corepack pnpm@9.6.0 test
- corepack pnpm@9.6.0 audit --audit-level=moderate

## Notes
- Existing unrelated changes in the main working tree were left untouched by using a clean git worktree.