### PR TITLE
fix(tools): declare shared config packages as ES modules

### DIFF
--- a/.changeset/tall-configs-type-module.md
+++ b/.changeset/tall-configs-type-module.md
@@ -1,0 +1,6 @@
+---
+"@opensourceframework/eslint-config": patch
+"@opensourceframework/prettier-config": patch
+---
+
+Declare the shared JavaScript config packages as ES modules so Node does not emit typeless-package warnings when loading their published entrypoints.

--- a/tools/eslint-config/package.json
+++ b/tools/eslint-config/package.json
@@ -4,6 +4,7 @@
   "private": false,
   "description": "Shared ESLint flat config for OpenSourceFramework packages",
   "license": "MIT",
+  "type": "module",
   "main": "index.js",
   "exports": {
     ".": "./index.js",

--- a/tools/prettier-config/package.json
+++ b/tools/prettier-config/package.json
@@ -4,6 +4,7 @@
   "private": false,
   "description": "Shared Prettier config for OpenSourceFramework packages",
   "license": "MIT",
+  "type": "module",
   "main": "index.js",
   "exports": {
     ".": "./index.js"


### PR DESCRIPTION
## Summary
- Adds `type: module` to `@opensourceframework/eslint-config` and `@opensourceframework/prettier-config` so their ESM `.js` entrypoints load without Node's `MODULE_TYPELESS_PACKAGE_JSON` warning.
- Adds a patch changeset for both published config packages.

## Root cause
The shared config packages publish JavaScript files that use ESM syntax, but their package manifests did not declare module type. Node 24 reparses them and emits typeless-package warnings; declaring the module type matches the published entrypoints.

## Tests
- `node --input-type=module -e "process.on('warning', w => { if (w.code === 'MODULE_TYPELESS_PACKAGE_JSON') { console.error('typeless warning'); process.exitCode = 1; } }); await import('@opensourceframework/prettier-config'); await new Promise(r => setImmediate(r));"`
- `node --input-type=module -e "process.on('warning', w => { if (w.code === 'MODULE_TYPELESS_PACKAGE_JSON') { console.error('typeless warning'); process.exitCode = 1; } }); await import('@opensourceframework/eslint-config'); await import('@opensourceframework/eslint-config/base'); await import('@opensourceframework/eslint-config/react'); await new Promise(r => setImmediate(r));"`
- `git diff --check`
- `corepack pnpm@9.6.0 lint`
- `corepack pnpm@9.6.0 typecheck`
- `corepack pnpm@9.6.0 test`
