### PR TITLE
ci(security): bound audit dependency install time

### DIFF
--- a/.github/workflows/security-audit.yml
+++ b/.github/workflows/security-audit.yml
@@ -15,16 +15,18 @@ jobs:
   audit:
     name: Security Audit
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - uses: actions/checkout@v4
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
 
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
           node-version: '20'
-
-      - name: Setup pnpm
-        uses: pnpm/action-setup@v4
+          cache: 'pnpm'
 
       - name: Cache pnpm store
         uses: actions/cache@v4
@@ -33,12 +35,13 @@ jobs:
             ~/.pnpm-store
             ~/.local/share/pnpm/store
             ~/.cache/pnpm
-          key: ${{ runner.os }}-pnpm-store-${{ hashFiles('pnpm-lock.yaml') }}
+          key: ${{ runner.os }}-pnpm-store-${{ hashFiles('pnpm-lock.yaml', 'pnpm-workspace.yaml') }}
           restore-keys: |
             ${{ runner.os }}-pnpm-store-
 
       - name: Install dependencies
-        run: pnpm install --frozen-lockfile
+        timeout-minutes: 10
+        run: pnpm install --frozen-lockfile --prefer-offline
 
       - name: Run npm audit
         run: pnpm audit --audit-level=moderate


### PR DESCRIPTION
## Summary
- Adds job and install-step timeouts to the standalone Security Audit workflow so dependency install cannot remain pending indefinitely.
- Aligns the workflow with the main CI install/cache pattern by setting up pnpm before Node cache, including pnpm-workspace.yaml in the cache key, and using --prefer-offline.

## Root cause
PR #285 has a standalone Security Audit push run stuck in the Install dependencies step for hours. The workflow had no job or step timeout, so a hung dependency install could leave PR checks pending indefinitely.

## Tests
- git diff --check
- corepack pnpm@9.6.0 install --frozen-lockfile --prefer-offline
- corepack pnpm@9.6.0 audit --audit-level=moderate
- staged secret scan