### PR TITLE
fix(next-optimized-images): isolate explicit loader detection

### DIFF
--- a/.changeset/quiet-badgers-resolve.md
+++ b/.changeset/quiet-badgers-resolve.md
@@ -1,0 +1,5 @@
+---
+'@opensourceframework/next-optimized-images': patch
+---
+
+Restrict explicit loader detection to the target project's node_modules so parent workspaces do not cause false positives.

--- a/packages/next-optimized-images/__tests__/loaders/index.test.js
+++ b/packages/next-optimized-images/__tests__/loaders/index.test.js
@@ -40,6 +40,22 @@ describe('next-optimized-images/loaders', () => {
     }
   });
 
+  it('does not detect loaders from parent node_modules when resolvePath is explicit', () => {
+    const parentPath = fs.mkdtempSync(path.join(os.tmpdir(), 'next-optimized-images-parent-'));
+    const projectPath = path.join(parentPath, 'project');
+    const parentLoaderPath = path.join(parentPath, 'node_modules', 'svg-sprite-loader');
+
+    try {
+      fs.mkdirSync(projectPath);
+      fs.mkdirSync(parentLoaderPath, { recursive: true });
+      fs.writeFileSync(path.join(parentLoaderPath, 'index.js'), 'module.exports = {};');
+
+      expect(detectLoaders(projectPath).svgSprite).toEqual(false);
+    } finally {
+      fs.rmSync(parentPath, { recursive: true, force: true });
+    }
+  });
+
   it('returns the handled image types', () => {
     expect(getHandledImageTypes(getConfig({}))).toEqual({
       jpeg: true,

--- a/packages/next-optimized-images/lib/loaders/index.js
+++ b/packages/next-optimized-images/lib/loaders/index.js
@@ -1,3 +1,5 @@
+const path = require('path');
+const { builtinModules } = require('module');
 const { applyImgLoader } = require('./img-loader');
 const { applyWebpLoader } = require('./webp-loader');
 const { applyResponsiveLoader } = require('./responsive-loader');
@@ -12,7 +14,21 @@ const { applyFileLoader } = require('./file-loader');
  */
 const isModuleInstalled = (name, resolvePath) => {
   try {
-    require.resolve(name, resolvePath ? { paths: [resolvePath] } : undefined);
+    if (resolvePath) {
+      const normalizedName = name.startsWith('node:') ? name.slice(5) : name;
+
+      if (builtinModules.includes(normalizedName)) {
+        return true;
+      }
+
+      const modulePath = name.startsWith('.') || path.isAbsolute(name)
+        ? path.resolve(resolvePath, name)
+        : path.join(resolvePath, 'node_modules', name);
+
+      require.resolve(modulePath);
+    } else {
+      require.resolve(name);
+    }
 
     return true;
   } catch {


### PR DESCRIPTION
## Summary
- restrict explicit loader checks to the target project's own node_modules instead of inherited parent node_modules
- add a regression test for parent workspace loader false positives
- add a patch changeset for @opensourceframework/next-optimized-images

## Tests
- corepack pnpm@9.6.0 --filter @opensourceframework/next-optimized-images test
- corepack pnpm@9.6.0 --filter @opensourceframework/next-optimized-images lint
- corepack pnpm@9.6.0 --filter @opensourceframework/next-optimized-images build
- corepack pnpm@9.6.0 test
- git diff --check