### PR TITLE
chore: ignore generated test results

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,6 +36,7 @@ yarn-error.log*
 # Testing
 coverage/
 .nyc_output/
+test-results/
 
 # Changesets
 .changeset/pre.json

--- a/packages/next-auth/test-results/.last-run.json
+++ b/packages/next-auth/test-results/.last-run.json
@@ -1,4 +1,0 @@
-{
-  "status": "passed",
-  "failedTests": []
-}

--- a/packages/next-pwa/test-app/test-results/.last-run.json
+++ b/packages/next-pwa/test-app/test-results/.last-run.json
@@ -1,4 +1,0 @@
-{
-  "status": "passed",
-  "failedTests": []
-}


### PR DESCRIPTION
## Summary
- Removes tracked Playwright/Vitest test result state files from next-auth and next-pwa
- Adds a root ignore for generated test-results directories so future local test runs do not dirty the tree

## Tests
- corepack pnpm@9.6.0 --filter @opensourceframework/next-auth test
- corepack pnpm@9.6.0 --filter @opensourceframework/next-pwa test
- git check-ignore -v packages/next-auth/test-results/.last-run.json packages/next-pwa/test-app/test-results/.last-run.json
- git diff --check
- staged changed-line secret scan