### PR TITLE
chore(ci): align compatibility smoke matrix

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -91,13 +91,13 @@ jobs:
             next-auth,
             react-virtualized,
           ]
-        next-version: ['14.2.24', '15.2.0', '16.1.6']
+        next-version: ['14.2.24', '15.2.0', '16.2.6']
         include:
           - next-version: '14.2.24'
             react-version: '18.3.1'
           - next-version: '15.2.0'
             react-version: '19.0.0'
-          - next-version: '16.1.6'
+          - next-version: '16.2.6'
             react-version: '19.2.0'
     steps:
       - uses: actions/checkout@v4

--- a/package.json
+++ b/package.json
@@ -11,8 +11,9 @@
   ],
   "scripts": {
     "prepare": "husky",
-    "test": "turbo run test",
+    "test": "node scripts/check-compat-matrix.mjs && turbo run test",
     "test:compat": "node scripts/test-compat.mjs",
+    "test:compat-matrix": "node scripts/check-compat-matrix.mjs",
     "test:coverage": "turbo run test:coverage",
     "test:ci": "turbo run test:ci",
     "test:types": "turbo run test:types",

--- a/scripts/check-compat-matrix.mjs
+++ b/scripts/check-compat-matrix.mjs
@@ -1,0 +1,73 @@
+#!/usr/bin/env node
+
+import { readFile } from 'node:fs/promises';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+
+function formatPair({ next, react }) {
+  return `Next.js ${next} / React ${react}`;
+}
+
+function formatPairs(pairs) {
+  return pairs.map(formatPair).sort().join('\n');
+}
+
+function assertSamePairs(actual, expected, label) {
+  const actualText = formatPairs(actual);
+  const expectedText = formatPairs(expected);
+
+  if (actualText !== expectedText) {
+    throw new Error(
+      [
+        `${label} compatibility matrix is out of sync with README.md.`,
+        '',
+        'Expected:',
+        expectedText,
+        '',
+        'Actual:',
+        actualText,
+      ].join('\n')
+    );
+  }
+}
+
+function uniquePairs(pairs) {
+  return [...new Map(pairs.map((pair) => [`${pair.next}|${pair.react}`, pair])).values()];
+}
+
+const readme = await readFile(path.join(repoRoot, 'README.md'), 'utf8');
+const releaseWorkflow = await readFile(
+  path.join(repoRoot, '.github/workflows/release.yml'),
+  'utf8'
+);
+const compatScript = await readFile(path.join(repoRoot, 'scripts/test-compat.mjs'), 'utf8');
+
+const readmePairs = uniquePairs(
+  [...readme.matchAll(/\*\*Next\.js ([^*]+)\*\*\s*\/\s*\*\*React ([^*]+)\*\*/g)].map(
+    ([, next, react]) => ({ next, react })
+  )
+);
+
+const releasePairs = uniquePairs(
+  [...releaseWorkflow.matchAll(/- next-version: '([^']+)'\n\s+react-version: '([^']+)'/g)].map(
+    ([, next, react]) => ({ next, react })
+  )
+);
+
+const compatPairs = uniquePairs(
+  [...compatScript.matchAll(/\{ next: '([^']+)', react: '([^']+)' \}/g)].map(([, next, react]) => ({
+    next,
+    react,
+  }))
+);
+
+if (readmePairs.length === 0) {
+  throw new Error('README.md compatibility matrix contains no Next.js / React pairs.');
+}
+
+assertSamePairs(releasePairs, readmePairs, '.github/workflows/release.yml');
+assertSamePairs(compatPairs, readmePairs, 'scripts/test-compat.mjs');
+
+console.log(`Compatibility matrices are in sync:\n${formatPairs(readmePairs)}`);

--- a/scripts/test-compat.mjs
+++ b/scripts/test-compat.mjs
@@ -501,47 +501,54 @@ async function main() {
     );
     const reactVirtualizedTarball = await packPackage('packages/react-virtualized', tarballDir);
 
-    
-    
-    
-    
-    
-    
-    
-
-    
     const versionMatrix = [
       { next: '14.2.24', react: '18.3.1' },
       { next: '15.2.0', react: '19.0.0' },
-      { next: '16.1.6', react: '19.2.0' }
+      { next: '16.2.6', react: '19.2.0' },
     ];
 
     for (const versions of versionMatrix) {
-      console.log(`\nRunning smoke tests for Next.js ${versions.next} / React ${versions.react}...`);
-      
+      console.log(
+        `\nRunning smoke tests for Next.js ${versions.next} / React ${versions.react}...`
+      );
+
       const versionTempRoot = path.join(tempRoot, versions.next.replace(/\./g, '-'));
       await mkdir(versionTempRoot, { recursive: true });
 
       await smokeNextImages(nextImagesTarball, versionTempRoot, versions);
-      console.log(`[SAFE] @opensourceframework/next-images is verified safe with Next.js ${versions.next} / React ${versions.react}`);
-      
+      console.log(
+        `[SAFE] @opensourceframework/next-images is verified safe with Next.js ${versions.next} / React ${versions.react}`
+      );
+
       await smokeNextComposePlugins(nextComposePluginsTarball, versionTempRoot, versions);
-      console.log(`[SAFE] @opensourceframework/next-compose-plugins is verified safe with Next.js ${versions.next} / React ${versions.react}`);
-      
+      console.log(
+        `[SAFE] @opensourceframework/next-compose-plugins is verified safe with Next.js ${versions.next} / React ${versions.react}`
+      );
+
       await smokeNextOptimizedImages(nextOptimizedImagesTarball, versionTempRoot, versions);
-      console.log(`[SAFE] @opensourceframework/next-optimized-images is verified safe with Next.js ${versions.next} / React ${versions.react}`);
-      
+      console.log(
+        `[SAFE] @opensourceframework/next-optimized-images is verified safe with Next.js ${versions.next} / React ${versions.react}`
+      );
+
       await smokeNextMdx(nextMdxTarball, nextMdxTocTarball, versionTempRoot, versions);
-      console.log(`[SAFE] @opensourceframework/next-mdx is verified safe with Next.js ${versions.next} / React ${versions.react}`);
-      
+      console.log(
+        `[SAFE] @opensourceframework/next-mdx is verified safe with Next.js ${versions.next} / React ${versions.react}`
+      );
+
       await smokeNextSession(nextSessionTarball, versionTempRoot, versions);
-      console.log(`[SAFE] @opensourceframework/next-session is verified safe with Next.js ${versions.next} / React ${versions.react}`);
-      
+      console.log(
+        `[SAFE] @opensourceframework/next-session is verified safe with Next.js ${versions.next} / React ${versions.react}`
+      );
+
       await smokeNextAuth(nextAuthTarball, versionTempRoot, versions);
-      console.log(`[SAFE] @opensourceframework/next-auth is verified safe with Next.js ${versions.next} / React ${versions.react}`);
-      
+      console.log(
+        `[SAFE] @opensourceframework/next-auth is verified safe with Next.js ${versions.next} / React ${versions.react}`
+      );
+
       await smokeReactVirtualized(reactVirtualizedTarball, versionTempRoot, versions);
-      console.log(`[SAFE] @opensourceframework/react-virtualized is verified safe with Next.js ${versions.next} / React ${versions.react}`);
+      console.log(
+        `[SAFE] @opensourceframework/react-virtualized is verified safe with Next.js ${versions.next} / React ${versions.react}`
+      );
     }
 
     console.log('Compatibility smoke checks passed.');


### PR DESCRIPTION
## Summary
- Updates release smoke tests and local compatibility smoke tests to use the documented Next.js 16.2.6 / React 19.2.0 row.
- Adds a fast compatibility-matrix guard so README, release workflow, and smoke-test script cannot drift silently again.
- Runs the guard at the start of the root test script.

## Tests
- corepack pnpm@9.6.0 run test:compat-matrix
- corepack pnpm@9.6.0 exec prettier --check package.json .github/workflows/release.yml scripts/test-compat.mjs scripts/check-compat-matrix.mjs
- git diff --check
- corepack pnpm@9.6.0 test
- corepack pnpm@9.6.0 lint
- corepack pnpm@9.6.0 audit --audit-level moderate