### PR TITLE
ci(release): force webpack for Next 16 image smokes

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -132,6 +132,13 @@ jobs:
             ls "$TARBALL_DIR"/opensourceframework-"$pkg"-*.tgz 2>/dev/null | head -1
           }
 
+          next_build_command() {
+            case "$SMOKE_NEXT" in
+              16.*) echo "next build --webpack" ;;
+              *) echo "next build" ;;
+            esac
+          }
+
           # next-mdx also needs next-mdx-toc
           if [ "$SMOKE_PACKAGE" = "next-mdx" ]; then
             MDX_TARBALL=$(find_tarball next-mdx)
@@ -152,8 +159,7 @@ jobs:
             next-images)
               FIXTURE="$TEMP_DIR/next-images"
               mkdir -p "$FIXTURE/assets" "$FIXTURE/pages"
-              BUILD_CMD="next build"
-              [ "$SMOKE_NEXT" = "16.1.6" ] && BUILD_CMD="next build --webpack"
+              BUILD_CMD="$(next_build_command)"
               cat > "$FIXTURE/package.json" <<EOF
           {"name":"compat","private":true,"scripts":{"build":"$BUILD_CMD"},"dependencies":{"@opensourceframework/next-images":"file:$TARBALL","next":"$SMOKE_NEXT","react":"$SMOKE_REACT","react-dom":"$SMOKE_REACT"}}
           EOF
@@ -188,8 +194,7 @@ jobs:
             next-optimized-images)
               FIXTURE="$TEMP_DIR/next-optimized-images"
               mkdir -p "$FIXTURE/assets" "$FIXTURE/pages"
-              BUILD_CMD="next build"
-              [ "$SMOKE_NEXT" = "16.1.6" ] && BUILD_CMD="next build --webpack"
+              BUILD_CMD="$(next_build_command)"
               cat > "$FIXTURE/package.json" <<EOF
           {"name":"compat","private":true,"scripts":{"build":"$BUILD_CMD"},"dependencies":{"@opensourceframework/next-optimized-images":"file:$TARBALL","next":"$SMOKE_NEXT","react":"$SMOKE_REACT","react-dom":"$SMOKE_REACT"}}
           EOF

--- a/scripts/check-compat-matrix.mjs
+++ b/scripts/check-compat-matrix.mjs
@@ -70,4 +70,16 @@ if (readmePairs.length === 0) {
 assertSamePairs(releasePairs, readmePairs, '.github/workflows/release.yml');
 assertSamePairs(compatPairs, readmePairs, 'scripts/test-compat.mjs');
 
+if (!releaseWorkflow.includes('16.*) echo "next build --webpack" ;;')) {
+  throw new Error(
+    '.github/workflows/release.yml must run webpack-backed image smoke tests with --webpack for every Next.js 16.x matrix entry.'
+  );
+}
+
+if (/SMOKE_NEXT"\s*=\s*"16\.\d+\.\d+"/.test(releaseWorkflow)) {
+  throw new Error(
+    '.github/workflows/release.yml must not pin Next.js 16 webpack smoke-test selection to a single patch version.'
+  );
+}
+
 console.log(`Compatibility matrices are in sync:\n${formatPairs(readmePairs)}`);


### PR DESCRIPTION
## Summary
- Fixes the failing Release workflow's Next 16 image smoke jobs by selecting `next build --webpack` for every 16.x matrix entry instead of only the old 16.1.6 version.
- Adds a compatibility-matrix guard so future Next 16 patch bumps don't silently drop the webpack flag.

## Root cause
Next.js 16 defaults to Turbopack. The image smoke fixtures install packages that add webpack config, but the Release workflow only forced webpack for `SMOKE_NEXT=16.1.6`. After the matrix moved to 16.2.6, the smoke build ran under Turbopack and failed with `This build is using Turbopack, with a webpack config and no turbopack config`.

## Tests
- `corepack pnpm@9.6.0 test:compat-matrix`
- `corepack pnpm@9.6.0 exec prettier --check .github/workflows/release.yml scripts/check-compat-matrix.mjs`
- Manual next-optimized-images fixture: reproduced `next build` failure on Next 16.2.6, verified `next build --webpack` passes
- Manual next-images fixture: verified `next build --webpack` passes on Next 16.2.6
- `corepack pnpm@9.6.0 test`
- `corepack pnpm@9.6.0 lint`