### PR TITLE
chore(react-query-auth): use pnpm for export check

### DIFF
--- a/packages/react-query-auth/package.json
+++ b/packages/react-query-auth/package.json
@@ -48,7 +48,7 @@
     "test": "vitest run",
     "test:cov": "vitest run --coverage",
     "test:coverage": "pnpm test:cov",
-    "postbuild": "npm run check:exports",
+    "postbuild": "pnpm run check:exports",
     "build": "tsup src/index.tsx --config tsup.config.ts",
     "example:dev": "npm run dev -w examples/vite",
     "build:dev": "tsup src/index.tsx --config tsup.dev.config.ts",


### PR DESCRIPTION
## Summary
- runs the react-query-auth postbuild export validation through pnpm instead of npm
- removes npm's unknown pnpm config warnings from package builds while preserving the attw export check

## Tests
- corepack pnpm@9.6.0 --filter @opensourceframework/react-query-auth build
- corepack pnpm@9.6.0 --filter @opensourceframework/react-query-auth test
- corepack pnpm@9.6.0 --filter @opensourceframework/react-query-auth typecheck
- git diff --check
- staged secret scan