### PR TITLE
ci: run Snyk scan without Docker action

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -373,12 +373,27 @@ jobs:
         run: pnpm audit --audit-level=moderate
         continue-on-error: true
 
-      # Snyk security scan for vulnerability detection
-      # Note: The SNYK_TOKEN is automatically masked by GitHub Actions and will not appear in logs.
-      # For detailed vulnerability reports, monitor the Snyk dashboard directly at https://snyk.io
-      # rather than relying solely on CI output.
+      - name: Check Snyk configuration
+        id: snyk
+        env:
+          SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
+        run: |
+          if [ -n "$SNYK_TOKEN" ]; then
+            echo "configured=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "configured=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      # Snyk security scan for vulnerability detection.
+      # Run the CLI through pnpm instead of the Docker-based action so CI does not fail while
+      # pulling snyk/snyk:node before continue-on-error can take effect.
       - name: Run Snyk Security Scan
-        uses: snyk/actions/node@master
+        if: ${{ steps.snyk.outputs.configured == 'true' }}
+        run: pnpm dlx snyk@latest test --all-projects --severity-threshold=medium
         continue-on-error: true
         env:
           SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
+
+      - name: Report missing Snyk configuration
+        if: ${{ steps.snyk.outputs.configured == 'false' }}
+        run: echo "Snyk scan skipped because SNYK_TOKEN is not configured." >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/security-audit.yml
+++ b/.github/workflows/security-audit.yml
@@ -43,7 +43,7 @@ jobs:
         timeout-minutes: 10
         run: pnpm install --frozen-lockfile --prefer-offline
 
-      - name: Run npm audit
+      - name: Run pnpm audit
         run: pnpm audit --audit-level=moderate
 
       - name: Check Snyk configuration
@@ -59,13 +59,13 @@ jobs:
 
       - name: Run Snyk Security Scan
         if: ${{ steps.snyk.outputs.configured == 'true' }}
-        uses: snyk/actions/node@master
+        run: pnpm dlx snyk@latest test --all-projects --severity-threshold=medium
         env:
           SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
 
       - name: Report missing Snyk configuration
         if: ${{ steps.snyk.outputs.configured == 'false' }}
-        run: echo "Snyk scan skipped because SNYK_TOKEN is not configured." >> $GITHUB_STEP_SUMMARY
+        run: echo "Snyk scan skipped because SNYK_TOKEN is not configured." >> "$GITHUB_STEP_SUMMARY"
 
       - name: Generate Security Report
         if: always()


### PR DESCRIPTION
## Summary
- Replaces the Docker-based `snyk/actions/node@master` scan with `pnpm dlx snyk@latest` in CI/security-audit workflows.
- Skips the CI Snyk scan cleanly when `SNYK_TOKEN` is not configured.
- Keeps `pnpm audit --audit-level=moderate` as the primary audit gate.

## Root cause
Main CI run 26802561157 failed before the Snyk step could honor `continue-on-error` because GitHub Actions had to pull `snyk/snyk:node` from Docker Hub and Docker Hub timed out.

## Tests run
- `python3` YAML parse for `.github/workflows/ci.yml` and `.github/workflows/security-audit.yml`
- `git diff --check`
- workflow assertions: no remaining `snyk/actions`, expected `pnpm dlx snyk@latest` command present
- `corepack pnpm@9.6.0 dlx snyk@latest --version`
- `corepack pnpm@9.6.0 audit --audit-level=moderate`
- pre-change baseline: `corepack pnpm@9.6.0 test`, `corepack pnpm@9.6.0 lint`, `corepack pnpm@9.6.0 typecheck`