### PR TITLE
fix(next-mdx-toc): align internal mdx dependency

### DIFF
--- a/.changeset/next-mdx-toc-dependency-20260602.md
+++ b/.changeset/next-mdx-toc-dependency-20260602.md
@@ -1,0 +1,5 @@
+---
+"@opensourceframework/next-mdx-toc": patch
+---
+
+Align the internal `@opensourceframework/next-mdx` dependency range with the current workspace release.

--- a/.github/workflows/security-audit.yml
+++ b/.github/workflows/security-audit.yml
@@ -41,7 +41,7 @@ jobs:
 
       - name: Install dependencies
         timeout-minutes: 10
-        run: pnpm install --frozen-lockfile --prefer-offline
+        run: pnpm install --frozen-lockfile --prefer-offline --ignore-scripts
 
       - name: Run pnpm audit
         run: pnpm audit --audit-level=moderate

--- a/packages/next-mdx-toc/package.json
+++ b/packages/next-mdx-toc/package.json
@@ -41,7 +41,7 @@
     "typescript": "^5.9.3"
   },
   "dependencies": {
-    "@opensourceframework/next-mdx": "^0.6.2",
+    "@opensourceframework/next-mdx": "^0.7.1",
     "mdast-util-toc": "^5.1.0",
     "remark": "^13.0.0",
     "unist-util-visit": "^2.0.3"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -742,8 +742,8 @@ importers:
   packages/next-mdx-toc:
     dependencies:
       '@opensourceframework/next-mdx':
-        specifier: ^0.6.2
-        version: 0.6.2(@types/react@19.2.14)(next@16.2.6(@babel/core@7.29.0)(@playwright/test@1.58.2)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react@19.2.4)
+        specifier: ^0.7.1
+        version: link:../next-mdx
       mdast-util-toc:
         specifier: ^5.1.0
         version: 5.1.0
@@ -3331,13 +3331,6 @@ packages:
 
   '@open-draft/until@2.1.0':
     resolution: {integrity: sha512-U69T3ItWHvLwGg5eJ0n3I62nWuE6ilHlmz7zM0npLBRvPRd7e6NYmg54vvRtP5mZG7kZqZCFVdsTWo7BPtBujg==}
-
-  '@opensourceframework/next-mdx@0.6.2':
-    resolution: {integrity: sha512-chySlDAmw+FmqTrZsOmBOkENci0ApX3p5ONiR/IFeYwpMsl7s5drEiGCGBjmdXQEH2l3vqFwTStlM8V3GZ8Tvw==}
-    engines: {node: '>=18.0.0'}
-    peerDependencies:
-      next: '>=16.2.6'
-      react: '>= 16.8.0'
 
   '@panva/asn1.js@1.0.0':
     resolution: {integrity: sha512-UdkG3mLEqXgnlKsWanWcgb6dOjUzJ+XC5f+aWw30qrtjxeNUSfKX1cd5FBzOaXQumoe9nIqeZUvrRJS03HCCtw==}
@@ -13730,7 +13723,7 @@ snapshots:
     dependencies:
       '@types/istanbul-lib-coverage': 2.0.6
       '@types/istanbul-reports': 3.0.4
-      '@types/node': 25.9.1
+      '@types/node': 22.19.15
       '@types/yargs': 15.0.20
       chalk: 4.1.2
 
@@ -13980,20 +13973,6 @@ snapshots:
       outvariant: 1.4.3
 
   '@open-draft/until@2.1.0': {}
-
-  '@opensourceframework/next-mdx@0.6.2(@types/react@19.2.14)(next@16.2.6(@babel/core@7.29.0)(@playwright/test@1.58.2)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react@19.2.4)':
-    dependencies:
-      '@mdx-js/react': 3.1.1(@types/react@19.2.14)(react@19.2.4)
-      crypto-hash: 4.0.1
-      fast-glob: 3.3.3
-      gray-matter: 4.0.3
-      next: 16.2.6(@babel/core@7.29.0)(@playwright/test@1.58.2)(babel-plugin-macros@3.1.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
-      next-mdx-remote: 6.0.0(@types/react@19.2.14)(react@19.2.4)
-      node-cache: 5.1.2
-      react: 19.2.4
-    transitivePeerDependencies:
-      - '@types/react'
-      - supports-color
 
   '@panva/asn1.js@1.0.0': {}
 
@@ -14952,6 +14931,7 @@ snapshots:
   '@types/node@25.9.1':
     dependencies:
       undici-types: 7.24.6
+    optional: true
 
   '@types/nodemailer@6.4.23':
     dependencies:
@@ -24145,7 +24125,8 @@ snapshots:
 
   undici-types@7.18.2: {}
 
-  undici-types@7.24.6: {}
+  undici-types@7.24.6:
+    optional: true
 
   unicode-canonical-property-names-ecmascript@2.0.1: {}
 


### PR DESCRIPTION
## Summary
- Updates @opensourceframework/next-mdx-toc to depend on the current workspace @opensourceframework/next-mdx release (^0.7.1)
- Regenerates the pnpm lockfile so next-mdx-toc links the workspace package instead of resolving the older 0.6.2 registry package
- Adds a patch changeset for next-mdx-toc
- Fixes the Security Audit workflow timeout by skipping lifecycle scripts during its dependency install; the audit reads lockfile/project metadata and does not need postinstall/prepare downloads

## Tests
- corepack pnpm@9.6.0 install --frozen-lockfile --prefer-offline
- corepack pnpm@9.6.0 install --frozen-lockfile --prefer-offline --ignore-scripts
- corepack pnpm@9.6.0 audit --audit-level=moderate
- corepack pnpm@9.6.0 --filter @opensourceframework/next-mdx-toc test
- corepack pnpm@9.6.0 --filter @opensourceframework/next-mdx-toc build
- corepack pnpm@9.6.0 changeset status --since origin/main
- git diff --check