### PR TITLE
fix(ci): run changesets publish command

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -344,7 +344,7 @@ jobs:
         id: changesets
         uses: changesets/action@v1
         with:
-          publish: pnpm release
+          publish: pnpm run publish
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/scripts/check-compat-matrix.mjs
+++ b/scripts/check-compat-matrix.mjs
@@ -5,6 +5,7 @@ import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 
 const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+const packageJson = JSON.parse(await readFile(path.join(repoRoot, 'package.json'), 'utf8'));
 
 function formatPair({ next, react }) {
   return `Next.js ${next} / React ${react}`;
@@ -80,6 +81,16 @@ if (/SMOKE_NEXT"\s*=\s*"16\.\d+\.\d+"/.test(releaseWorkflow)) {
   throw new Error(
     '.github/workflows/release.yml must not pin Next.js 16 webpack smoke-test selection to a single patch version.'
   );
+}
+
+if (!releaseWorkflow.includes('publish: pnpm run publish')) {
+  throw new Error(
+    '.github/workflows/release.yml changesets/action must run the root publish script so release PR merges actually publish packages.'
+  );
+}
+
+if (packageJson.scripts?.publish !== 'changeset publish') {
+  throw new Error('package.json publish script must run `changeset publish`.');
 }
 
 console.log(`Compatibility matrices are in sync:\n${formatPairs(readmePairs)}`);


### PR DESCRIPTION
## Summary
- Fixes the Release workflow so changesets/action runs the root publish script (`pnpm run publish`) instead of the versioning-only `pnpm release` script.
- Adds a release-workflow assertion to the existing compatibility precheck so future release PR merges cannot silently skip `changeset publish`.

## Evidence
- PR #296 merged and the Release workflow completed, but the Publish job log only rebuilt packages and did not invoke `changeset publish`.
- `npm view @opensourceframework/next-mdx-toc versions --json` still returned only `0.1.3` after the 0.1.8 release workflow, confirming publication did not happen.

## Tests
- `node scripts/check-compat-matrix.mjs`
- `corepack pnpm@9.6.0 --filter @opensourceframework/next-mdx-toc test`
- `corepack pnpm@9.6.0 --filter @opensourceframework/next-mdx-toc build`
- `corepack pnpm@9.6.0 lint`
- `corepack pnpm@9.6.0 test`

## Review
- `git diff --check`
- staged secret scan: ok
