### PR TITLE
docs: correct publishing troubleshooting

### DIFF
--- a/PUBLISHING.md
+++ b/PUBLISHING.md
@@ -82,13 +82,16 @@ For emergency releases, you can manually publish:
 pnpm build
 
 # Publish to npm
-pnpm release
+pnpm run publish
 ```
 
-For canary releases (pre-release versions):
+There is no canary publish script configured in this repository today. If a canary release is
+needed, add and review a dedicated script before using it in CI.
+
+For example, a future canary script might publish with a non-latest tag:
 
 ```bash
-pnpm release:canary
+changeset publish --tag canary
 ```
 
 ## Release Workflow
@@ -137,6 +140,12 @@ If you see `EPUBLISHCONFLICT`:
 If you see permission errors for `@opensourceframework`:
 1. Verify your npm account is a member of the organization
 2. Check with org admins for proper permissions
+
+If `changeset publish` reports `E404 Not Found - PUT https://registry.npmjs.org/@opensourceframework%2f...`
+for scoped packages, treat it as a likely npm token/scope permission problem rather than a missing
+package. npm can return 404 for package writes when the token cannot publish to the scope. Verify
+that the GitHub Actions `NPM_TOKEN` secret belongs to an npm account or automation token with write
+access to the `@opensourceframework` organization, then rerun the Release workflow.
 
 ## Additional Resources
 

--- a/scripts/check-compat-matrix.mjs
+++ b/scripts/check-compat-matrix.mjs
@@ -39,6 +39,7 @@ function uniquePairs(pairs) {
 }
 
 const readme = await readFile(path.join(repoRoot, 'README.md'), 'utf8');
+const publishingGuide = await readFile(path.join(repoRoot, 'PUBLISHING.md'), 'utf8');
 const releaseWorkflow = await readFile(
   path.join(repoRoot, '.github/workflows/release.yml'),
   'utf8'
@@ -91,6 +92,18 @@ if (!releaseWorkflow.includes('publish: pnpm run publish')) {
 
 if (packageJson.scripts?.publish !== 'changeset publish') {
   throw new Error('package.json publish script must run `changeset publish`.');
+}
+
+if (!publishingGuide.includes('pnpm run publish')) {
+  throw new Error('PUBLISHING.md must document `pnpm run publish` as the manual publish command.');
+}
+
+if (/pnpm release(?:\s|$)/.test(publishingGuide)) {
+  throw new Error('PUBLISHING.md must not document `pnpm release` as a publish command.');
+}
+
+if (/pnpm release:canary/.test(publishingGuide)) {
+  throw new Error('PUBLISHING.md must not document an unconfigured `pnpm release:canary` script.');
 }
 
 console.log(`Compatibility matrices are in sync:\n${formatPairs(readmePairs)}`);


### PR DESCRIPTION
## Summary
- corrects the manual publish command in `PUBLISHING.md` to use the actual root `publish` script
- removes the documented `pnpm release:canary` command because no such script exists in this repo
- documents npm scoped-package `E404 ... PUT` failures as likely `NPM_TOKEN`/scope permission issues
- extends the compatibility guard so the publishing guide cannot drift back to stale release commands

## Release failure evidence
The post-merge Release run 26834497574 reached `changeset publish`, then failed publishing every unpublished `@opensourceframework/*` package with `E404 Not Found - PUT https://registry.npmjs.org/@opensourceframework%2f...`. Public `npm view` checks still see existing packages such as `@opensourceframework/next-mdx-toc@0.1.3`, so the remaining blocker is likely the GitHub Actions `NPM_TOKEN` lacking write access to the `@opensourceframework` npm scope, not the release command itself.

## Tests run
- `corepack pnpm@9.6.0 exec prettier --check PUBLISHING.md scripts/check-compat-matrix.mjs`
- `corepack pnpm@9.6.0 test:compat-matrix`
- `git diff --check`
- `corepack pnpm@9.6.0 lint`
