### PR TITLE
test(next-connect): silence expected edge error log

### DIFF
--- a/packages/next-connect/test/edge.test.ts
+++ b/packages/next-connect/test/edge.test.ts
@@ -37,15 +37,20 @@ describe("EdgeRouter", () => {
 
   test("handler() - handles errors", async () => {
     const error = new Error("💥");
+    const consoleSpy = vi.spyOn(console, "error").mockImplementation(() => {});
     const req = new Request("http://localhost/");
-    const router = createEdgeRouter<Request, any>()
-      .get(() => {
-        throw error;
-      });
-    
-    const res = await router.handler()(req, {});
-    expect(res).toBeInstanceOf(Response);
-    expect((res as Response).status).toBe(500);
+    const router = createEdgeRouter<Request, any>().get(() => {
+      throw error;
+    });
+
+    try {
+      const res = await router.handler()(req, {});
+      expect(res).toBeInstanceOf(Response);
+      expect((res as Response).status).toBe(500);
+      expect(consoleSpy).toHaveBeenCalledWith(error);
+    } finally {
+      consoleSpy.mockRestore();
+    }
   });
 
   test("handler() - custom onError", async () => {


### PR DESCRIPTION
## Summary
- Spies on the expected default edge `console.error` path in the next-connect edge handler test
- Asserts the default error logger receives the thrown error while keeping Vitest stderr clean

## Tests
- `corepack pnpm@9.6.0 --filter @opensourceframework/next-connect test`
- `corepack pnpm@9.6.0 --filter @opensourceframework/next-connect lint`
- `corepack pnpm@9.6.0 lint`
- `corepack pnpm@9.6.0 test`
- `corepack pnpm@9.6.0 audit --audit-level moderate`
