### PR TITLE
fix(next-transpile-modules): use pnpm for pretest setup

### DIFF
--- a/packages/next-transpile-modules/package.json
+++ b/packages/next-transpile-modules/package.json
@@ -17,7 +17,7 @@
     "update:next": "npm run setup && bash scripts/next-update.sh",
     "typings": "tsc",
     "prepublishOnly": "npm run build && npm run typings",
-    "pretest": "npm run setup",
+    "pretest": "pnpm run setup",
     "quickie": "node --trace-uncaught src/__tests__/setup.js && yarn --cwd src/__tests__/__apps__/swc/app run dev",
     "test": "vitest run --passWithNoTests",
     "test:coverage": "pnpm test",

--- a/packages/next-transpile-modules/test/package-scripts.test.ts
+++ b/packages/next-transpile-modules/test/package-scripts.test.ts
@@ -1,0 +1,13 @@
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+const packageJson = JSON.parse(readFileSync(join(__dirname, '..', 'package.json'), 'utf8')) as {
+  scripts: Record<string, string>;
+};
+
+describe('package scripts', () => {
+  it('uses pnpm for the package-local pretest setup step', () => {
+    expect(packageJson.scripts.pretest).toBe('pnpm run setup');
+  });
+});


### PR DESCRIPTION
## Summary
- Switches next-transpile-modules pretest setup from npm to pnpm so pnpm workspace config is not passed through npm.
- Adds a regression test for the package-local pretest script.

## Tests
- corepack pnpm@9.6.0 --filter @opensourceframework/next-transpile-modules test
- corepack pnpm@9.6.0 --filter @opensourceframework/next-transpile-modules run typings
- corepack pnpm@9.6.0 exec eslint packages/next-transpile-modules/test/package-scripts.test.ts
- corepack pnpm@9.6.0 exec prettier --check packages/next-transpile-modules/test/package-scripts.test.ts
- git diff --check