### PR TITLE
fix(next-auth): resolve scoped type test imports

### DIFF
--- a/packages/next-auth/types/tsconfig.json
+++ b/packages/next-auth/types/tsconfig.json
@@ -17,7 +17,12 @@
       "next-auth/providers": ["./providers"],
       "next-auth/adapters": ["./adapters"],
       "next-auth/client": ["./client"],
-      "next-auth/jwt": ["./jwt"]
+      "next-auth/jwt": ["./jwt"],
+      "@opensourceframework/next-auth": ["."],
+      "@opensourceframework/next-auth/providers": ["./providers"],
+      "@opensourceframework/next-auth/adapters": ["./adapters"],
+      "@opensourceframework/next-auth/client": ["./client"],
+      "@opensourceframework/next-auth/jwt": ["./jwt"]
     }
   }
 }


### PR DESCRIPTION
## Summary
- Adds scoped @opensourceframework/next-auth path aliases to the next-auth type-test tsconfig
- Fixes the next-auth test:ci typecheck failure where scoped provider/adapter imports resolved to JS entrypoints instead of local declaration files

## Tests
- corepack pnpm@9.6.0 --filter @opensourceframework/next-auth test:ci
- corepack pnpm@9.6.0 typecheck
- corepack pnpm@9.6.0 test
- corepack pnpm@9.6.0 lint
- corepack pnpm@9.6.0 audit --audit-level=moderate --json