### PR TITLE
fix(react-virtualized): exclude examples from coverage

### DIFF
--- a/packages/react-virtualized/test/index.test.ts
+++ b/packages/react-virtualized/test/index.test.ts
@@ -26,4 +26,12 @@ describe('@opensourceframework/react-virtualized', () => {
     expect(readme).not.toContain("import 'react-virtualized");
     expect(readme).not.toContain("from 'react-virtualized");
   });
+
+  it('keeps coverage collection focused on runtime sources', async () => {
+    const config = await readFile(join(__dirname, '..', 'vitest.config.mts'), 'utf8');
+
+    expect(config).toContain("'source-stripped/**/*.example.jsx'");
+    expect(config).toContain("'source-stripped/demo/**'");
+    expect(config).toContain("'source-stripped/vendor/**'");
+  });
 });

--- a/packages/react-virtualized/vitest.config.mts
+++ b/packages/react-virtualized/vitest.config.mts
@@ -15,7 +15,16 @@ export default defineConfig({
       provider: 'v8',
       reporter: ['text', 'json', 'html'],
       include: ['source-stripped/**'],
-      exclude: ['source-stripped/**/*.jest.jsx'],
+      exclude: [
+        'source-stripped/**/*.jest.jsx',
+        'source-stripped/**/*.e2e.jsx',
+        'source-stripped/**/*.example.jsx',
+        'source-stripped/**/*.ssr.jsx',
+        'source-stripped/demo/**',
+        'source-stripped/jest-setup.jsx',
+        'source-stripped/TestUtils.jsx',
+        'source-stripped/vendor/**',
+      ],
     },
   },
 });


### PR DESCRIPTION
## Summary
- Excludes react-virtualized example, demo, SSR, e2e, setup, and vendor files from V8 coverage collection
- Adds a regression check so coverage config stays focused on runtime sources
- Removes the noisy Rollup parse warnings from react-virtualized coverage runs

## Tests
- corepack pnpm@9.6.0 --filter @opensourceframework/react-virtualized test
- corepack pnpm@9.6.0 --filter @opensourceframework/react-virtualized test:coverage (PARSE_WARNING_COUNT=0)
- corepack pnpm@9.6.0 --filter @opensourceframework/react-virtualized lint
- corepack pnpm@9.6.0 --filter @opensourceframework/react-virtualized typecheck
- git diff --check