### PR TITLE
docs: add docs workspace readme

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,23 @@
+# OpenSourceFramework docs
+
+This workspace contains the Nextra/Next.js documentation app for the monorepo.
+
+## Local development
+
+From the repository root:
+
+```bash
+corepack pnpm@9.6.0 --filter docs dev
+```
+
+Or from this directory:
+
+```bash
+corepack pnpm@9.6.0 dev
+```
+
+## Build behavior
+
+The `docs` package currently keeps its `build` script as a no-op so the monorepo build can run package validation without trying to produce a docs-site artifact. That script points here intentionally so maintainers know why docs builds are skipped.
+
+Run `corepack pnpm@9.6.0 --filter docs dev` when editing pages under `docs/app/`.


### PR DESCRIPTION
## Summary
- Adds the missing docs workspace README that the docs build script points maintainers to.
- Documents local docs development commands and why the docs package build is currently a no-op in monorepo validation.

## Tests
- `test -f docs/README.md && corepack pnpm@9.6.0 --filter docs build`
- `corepack pnpm@9.6.0 lint`
- `corepack pnpm@9.6.0 test`
- `git diff --check`
- staged changed-line secret scan