### PR TITLE
docs(next-images): refresh publication checklist

### DIFF
--- a/plans/publication-checklist.md
+++ b/plans/publication-checklist.md
@@ -106,24 +106,24 @@ The following tests are failing and need investigation before publication:
 
 **Status: ✅ Ready**
 
-**Package Type:** Fork (MIT license, original by twopluszero)
+**Package Type:** Maintained compatibility fork (MIT license, original by Aref Aslani)
 
 **Metadata:**
 - Name: `@opensourceframework/next-images`
-- Version: `1.8.7`
+- Version: `1.9.3`
 - License: MIT
-- Author: OpenSource Framework Contributors
+- Author: OpenSource Framework Contributors (fork), Original: Aref Aslani
 - Repository: https://github.com/opensourceframework/opensourceframework
 
 **Checklist:**
 - [x] package.json configured correctly
 - [x] LICENSE file present (MIT)
 - [x] Build successful
-- [x] Tests passing (40 tests)
+- [x] Tests passing (11 tests)
 - [x] README with badges
 - [x] Changeset created
 
-**Note:** This package is deprecated. Next.js 10+ includes a built-in Image component.
+**Note:** This package remains actively maintained as a compatibility option for teams that rely on the classic `next-images` plugin workflow. `next/image` may be a good fit for new applications, but the fork is not deprecated solely because Next.js includes a native image component.
 
 **Ready to publish:** Yes
 


### PR DESCRIPTION
## Description
Updates the publication checklist entry for @opensourceframework/next-images so it matches the current maintained-compatibility package strategy and the package's current metadata.

## Related Issue
N/A

## Type of Change
- [x] Documentation update

## Affected Package(s)
- [x] @opensourceframework/next-images
- [ ] Repository/tooling

## Checklist
- [x] I have read the Contributing Guidelines / repo guidance
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
- [x] Changeset not required (docs-only plan/checklist update)

## Tests run
- git diff --check
- corepack pnpm@9.6.0 exec prettier --check plans/publication-checklist.md
- corepack pnpm@9.6.0 --filter @opensourceframework/next-images test
- corepack pnpm@9.6.0 test
- corepack pnpm@9.6.0 lint
- corepack pnpm@9.6.0 typecheck
- corepack pnpm@9.6.0 audit --audit-level moderate --json